### PR TITLE
add vimperator and pentadactyl support

### DIFF
--- a/mackup.py
+++ b/mackup.py
@@ -65,6 +65,9 @@ SUPPORTED_APPS = {
 
     'Oh My Zsh': ['.oh-my-zsh'],
 
+    'Pentadactyl': ['.pentadactyl',
+                    '.pentadactylrc'],
+
     'S3cmd': ['.s3cfg'],
 
     'Sequel Pro': ['Library/Application Support/Sequel Pro/Data'],
@@ -80,6 +83,9 @@ SUPPORTED_APPS = {
 
     'Vim': ['.vim',
             '.vimrc'],
+
+    'Vimperator': ['.vimperator',
+                   '.vimperatorrc'],
 
     'X11': ['.Xresources',
             '.fonts'],


### PR DESCRIPTION
Not sure whether these fit your config criteria but this pull request adds support for the following Firefox plugins:
- Vimperator - http://www.vimperator.org/vimperator
- Pentadactyl - http://5digits.org/pentadactyl/

These plugins provide a, "vim in the browser" experience.
