### PR TITLE
Fix typo in confirmation prompt

### DIFF
--- a/mackup.py
+++ b/mackup.py
@@ -270,7 +270,7 @@ class ApplicationProfile(object):
 
                     # Ask the user if he really want to replace it
                     if confirm("A {} named {} already exists in the backup."
-                               "\nOr you sure that your want to replace it ?"
+                               "\nAre you sure that your want to replace it ?"
                                .format(file_type, mackup_filepath)):
                         # Delete the file in Mackup
                         delete(mackup_filepath)


### PR DESCRIPTION
Correct prompt shown when replacing a directory
that already exists in the backup directory.

Signed-off-by: Doug Hellmann doug.hellmann@gmail.com
