### PR TITLE
Add .git_hooks support

### DIFF
--- a/mackup.py
+++ b/mackup.py
@@ -80,7 +80,8 @@ SUPPORTED_APPS = {
         PREFERENCES + 'org.tynsoe.geektool3.plist'],
 
     'Git': ['.gitconfig',
-            '.gitignore_global'],
+            '.gitignore_global',
+            '.git_hooks'],
 
     'GnuPG': ['.gnupg'],
 


### PR DESCRIPTION
Back up the .git_hooks directory created by
https://github.com/icefox/git-hooks

Signed-off-by: Doug Hellmann doug.hellmann@gmail.com
