### PR TITLE
Add support for Python Package Index

### DIFF
--- a/mackup.py
+++ b/mackup.py
@@ -119,6 +119,8 @@ SUPPORTED_APPS = {
             '.powenv',
             '.powrc'],
 
+    'PyPI': ['.pypirc'],
+
     'Quicksilver': [PREFERENCES + 'com.blacktree.Quicksilver.plist',
                     APP_SUPPORT + 'Quicksilver'],
 


### PR DESCRIPTION
Backup the configuration file that holds the
user's credentials for communicating with
pypi.python.org.

Signed-off-by: Doug Hellmann doug.hellmann@gmail.com
