### PR TITLE
added a note about closing sublime text before running the utility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Keep your Mac application settings in sync.
 
 Install [Dropbox](http://www.dropbox.com/) first, it's needed.
 
+Close Sublime Text if you have it installed and open to avoid error messages when package files are moved.
+
 On your current Mac:
 ```bash
 # Download Mackup


### PR DESCRIPTION
When ST2 is open and the utility is run, ST2 will throw errors for every file in the packages directory that is moved.  This can cause your whole system to crash.  If ST2 is not open there is no issue.
