### PR TITLE
added a .mackup.cfg file to define apps that should not be backed up.

### DIFF
--- a/.mackup.cfg
+++ b/.mackup.cfg
@@ -1,0 +1,5 @@
+[ignore_apps]
+# a tuple of the apps you want to ignore e.g.
+# apps=ssh,Adium,etc
+apps=SSH,Adium
+


### PR DESCRIPTION
The .mackup.cfg file can hold a bunch of settings but all I implemented is the ability to ignore apps by a comma delimited string matching the `SUPPORTED_APPS` key
