### PR TITLE
Added a comma to line 223 to fix a syntax error preventing launch

### DIFF
--- a/mackup.py
+++ b/mackup.py
@@ -220,7 +220,7 @@ SUPPORTED_APPS = {
     'Xcode': ['Library/Developer/Xcode/UserData/CodeSnippets',
               'Library/Developer/Xcode/UserData/FontAndColorThemes',
               'Library/Developer/Xcode/UserData/KeyBindings',
-              'Library/Developer/Xcode/UserData/SearchScopes.xcsclist']
+              'Library/Developer/Xcode/UserData/SearchScopes.xcsclist'],
 
     'XEmacs': ['.xemacs'],
 


### PR DESCRIPTION
Changed line 223 from:

```
              'Library/Developer/Xcode/UserData/SearchScopes.xcsclist']
```

to:

```
              'Library/Developer/Xcode/UserData/SearchScopes.xcsclist'],
```

AKA, I added a comma to the end.  :)  Otherwise, this happens at launch:

```
       File "./mackup.py", line 225
         'XEmacs': ['.xemacs'],
                ^
     SyntaxError: invalid syntax
```
