### PR TITLE
Added support for Spark and CoRD

### DIFF
--- a/mackup.py
+++ b/mackup.py
@@ -77,6 +77,8 @@ SUPPORTED_APPS = {
 
     'ControlPlane': [PREFERENCES + 'com.dustinrue.ControlPlane.plist'],
 
+    'CoRD': [APP_SUPPORT + 'CoRD'],
+
     'Emacs': ['.emacs',
               '.emacs.d'],
 
@@ -177,6 +179,8 @@ SUPPORTED_APPS = {
                    APP_SUPPORT + 'SourceTree/browser.plist',
                    APP_SUPPORT + 'SourceTree/hgrc_sourcetree',
                    APP_SUPPORT + 'SourceTree/hostingservices.plist'],
+
+    'Spark': [APP_SUPPORT + 'Spark'],
 
     'SSH': ['.ssh'],
 


### PR DESCRIPTION
Added support for;

Spark - www.shadowlab.org/softwares/spark.php 
Spark is a helpful program to create Keyboard Shortcuts on your Mac. My using mackup, the shortcuts can be sync's across multiple machines in a super easy fashion.

CoRD http://cord.sourceforge.net/
CoRD is one of the best multiple RDP Client's for OS X. By using mackup, you are able to sync the settings for different connections across multiple OS X machines.
