### PR TITLE
Add support for Shuttle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Added support for Shuttle (thx @yabawock)
+
 ## Mackup 0.4.4
 
 - Conflict folder sync fix (thx @ediventurin)

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ That's it, you got your `git` config setup on your new Mac.
   - [Screen](http://www.gnu.org/software/screen/)
   - [Sequel Pro](http://www.sequelpro.com/)
   - [SHSH Blobs](http://en.wikipedia.org/wiki/SHSH_blob)
+  - [Shuttle](http://fitztrev.github.io/shuttle/)
   - [SizeUp](http://www.irradiatedsoftware.com/sizeup/)
   - [Slate](https://github.com/jigish/slate)
   - [Slogger](http://brettterpstra.com/projects/slogger/)

--- a/mackup.py
+++ b/mackup.py
@@ -266,6 +266,8 @@ SUPPORTED_APPS = {
 
     'SHSH Blobs': ['.shsh'],
 
+    'Shuttle': ['.shuttle.json'],
+
     'SizeUp': [PREFERENCES + 'com.irradiatedsoftware.SizeUp.plist',
                APP_SUPPORT + 'SizeUp/SizeUp.sizeuplicense'],
 


### PR DESCRIPTION
Shuttle is a simple SSH shortcut menu for OS X
