### PR TITLE
Add simulate and verbose arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ folder in Dropbox. This will revert your system at pre-Mackup state.
 
 Get some help, obvious...
 
+### Options
+
+`-S`, `--simulate`
+
+Simulate the Mackup operation but don't actually do anything.
+
+`-v`, `--verbose`
+
+Show verbose output for file operations.
+
 ## What does it do ?
 
 - Backups your application settings in Dropbox

--- a/mackup.py
+++ b/mackup.py
@@ -696,6 +696,23 @@ class Mackup(object):
                 error("Mackup can't do anything without a home =(")
 
 
+class State(object):
+    """Object to store state"""
+
+    _shared_state = {}
+
+    def __init__(self):
+        self.__dict__ = self._shared_state
+
+    def set_args(self, val):
+        self._args = val
+
+    def get_args(self):
+        return getattr(self, '_args', None)
+
+    args = property(get_args, set_args)
+
+
 ####################
 # Useful functions #
 ####################
@@ -731,6 +748,12 @@ def delete(filepath):
     Args:
         filepath (str): Absolute full path to a file. e.g. /path/to/file
     """
+    args = State().args
+    if args and args.verbose:
+        print "Deleting {}".format(filepath)
+    if args and args.simulate:
+        return
+
     # Some files have ACLs, let's remove them recursively
     remove_acl(filepath)
 
@@ -761,6 +784,12 @@ def copy(src, dst):
         src (str): Source file or folder
         dst (str): Destination file or folder
     """
+    args = State().args
+    if args and args.verbose:
+        print "Copying {} to {}".format(src, dst)
+    if args and args.simulate:
+        return
+
     assert isinstance(src, str)
     assert os.path.exists(src)
     assert isinstance(dst, str)
@@ -803,6 +832,12 @@ def link(target, link):
         target (str): file or folder the link will point to
         link (str): Link to create
     """
+    args = State().args
+    if args and args.verbose:
+        print "Linking {} to {}".format(link, target)
+    if args and args.simulate:
+        return
+
     assert isinstance(target, str)
     assert os.path.exists(target)
     assert isinstance(link, str)
@@ -896,6 +931,10 @@ def parse_cmdline_args():
                               " system you use.\n"
                               "Uninstall will reset everything as it was"
                               " before using Mackup."))
+
+    # Simulate and verbose options.
+    parser.add_argument("-S", "--simulate", action="store_true", help="Simulate the Mackup operation but don't actually do anything.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Show verbose output for file operations.")
 
     # Parse the command line and return the parsed options
     return parser.parse_args()
@@ -1086,6 +1125,9 @@ def main():
 
     # Get the command line arg
     args = parse_cmdline_args()
+    # Store command line arguments in a global state object.
+    state = State()
+    state.args = args
 
     mackup = Mackup()
 

--- a/mackup.py
+++ b/mackup.py
@@ -728,6 +728,10 @@ def confirm(question):
     Returns:
         (boolean): Confirmed or not
     """
+    args = State().args
+    if args and args.simulate:
+        return True
+
     while True:
         answer = raw_input(question + ' <Yes|No>')
         if answer == 'Yes':


### PR DESCRIPTION
I pretty much couldn't imagine using Mackup without being able to test it first using this functionality, so I decided I'd try and write it!

I'm definitely a Python newbie so please be kind and let me know if I've done anything (or everything) horribly wrong :)

I had to do some research to avoid using globals and I copped the State class from here: http://stackoverflow.com/a/747888/771643.

I didn't think it made sense to pass args to the file operation commands. Doing so would fix the `args and args.simulate` verbosity (added to fix failing tests due to no State object) but I think I'd rather have verbosity there than on the calling side. Any suggestions on improving that are definitely welcome.