### PR TITLE
reference containers

### DIFF
--- a/mackup.py
+++ b/mackup.py
@@ -47,6 +47,7 @@ except ImportError:
 MACKUP_DB_PATH = 'Mackup'
 PREFERENCES = 'Library/Preferences/'
 APP_SUPPORT = 'Library/Application Support/'
+CONTAINERS = 'Library/Containers/'
 
 #################
 # Configuration #


### PR DESCRIPTION
It seems like some apps store their preferences inside `~/Library/Containers/`. These directories are full of symlinks to other directories and files (so syncing the whole container would be a bad idea), but they have some that are not symlinks and seem to indeed store the app’s preferences.

Just did some small tests, and it seems to work. This happens with Mac App Store apps, and appears to be related with sandboxing.

Recommending this simple addition as I’m right now preparing some apps for submission (including Sketch, Pixelmator, and Tweetbot; [Sparrow](https://github.com/lra/mackup/pull/43) could benefit as well), but I’d like to know before if this is accepted (so I can link to them without using the full path every time).
