### PR TITLE
Allow selective restore

### DIFF
--- a/mackup.py
+++ b/mackup.py
@@ -1102,7 +1102,7 @@ def main():
         # Check the env where the command is being run
         mackup.check_for_usable_restore_env()
 
-        for app_name in SUPPORTED_APPS:
+        for app_name in get_apps_to_backup():
             app = ApplicationProfile(mackup, SUPPORTED_APPS[app_name])
             app.restore()
 


### PR DESCRIPTION
If .mackup.cfg exists the allowed and ignored applications will be respected when restoring. This allows for backing up different applications per machine.

I wanted different applications backed up on my work machine but hooked up to the same Dropbox account, this allows for that. This is actually how I assumed things would work, and found out that things didn't work this way by testing first with the code from #140.
