### PR TITLE
Backup only the `User` folder

### DIFF
--- a/mackup.py
+++ b/mackup.py
@@ -370,8 +370,7 @@ SUPPORTED_APPS = {
                        APP_SUPPORT + 'Sublime Text 2/Packages',
                        APP_SUPPORT + 'Sublime Text 2/Pristine Packages'],
 
-    'Sublime Text 3': [APP_SUPPORT + 'Sublime Text 3/Installed Packages',
-                       APP_SUPPORT + 'Sublime Text 3/Packages'],
+    'Sublime Text 3': [APP_SUPPORT + 'Sublime Text 3/Packages/User'],
 
     'Subversion': ['.subversion'],
 


### PR DESCRIPTION
> I know this pull request is closed and merged, but the prefered way to sync settings and packages in Sublime Text 3 changed a bit: https://sublime.wbond.net/docs/syncing "The proper solution is to sync only the Packages/User/ folder"

[Source](https://github.com/lra/mackup/pull/14#issuecomment-31570790)
