### PR TITLE
added support for readkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Added support for Readkit (thx @vitorgalvao)
+
 ## Mackup 0.6
 
 - Added support for custom applications

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ folder and destroy the Mackup folder in Dropbox.
   - [PyPI](https://pypi.python.org/pypi)
   - [Quicksilver](http://qsapp.com/)
   - [Rails](http://rubyonrails.org/)
+  - [Readkit](http://readkitapp.com/)
   - [rTorrent](http://libtorrent.rakshasa.no/)
   - [Ruby Version](https://gist.github.com/fnichol/1912050)
   - [Ruby](http://ruby-lang.org/)

--- a/mackup/applications/readkit.cfg
+++ b/mackup/applications/readkit.cfg
@@ -1,0 +1,6 @@
+[application]
+name = Readkit
+
+[configuration_files]
+Library/Containers/com.webinhq.ReadKit/Data/Library/Application Support/ReadKit/ReadKit.storedata
+Library/Containers/com.webinhq.ReadKit/Data/Library/Preferences/com.webinhq.ReadKit.plist


### PR DESCRIPTION
Since it’s under `Library/Containers`, this probably should wait until `mackup` can handle that.
