### PR TITLE
Add the option to override the location of the dropbox host file

### DIFF
--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -232,7 +232,11 @@ def get_dropbox_folder_location():
     Returns:
         (str) Full path to the current Dropbox folder
     """
-    host_db_path = os.environ['HOME'] + '/.dropbox/host.db'
+    if os.environ.has_key("MACKUP_DROPBOX_HOST_DB"):
+        host_db_path = os.path.expanduser(os.path.expandvars(os.environ['MACKUP_DROPBOX_HOST_DB']))
+    else:
+        host_db_path = os.environ['HOME'] + '/.dropbox/host.db'
+
     with open(host_db_path, 'r') as f_hostdb:
         data = f_hostdb.read().split()
     dropbox_home = base64.b64decode(data[1])


### PR DESCRIPTION
Add the option to override the location of the dropbox host file with an environment variable (for people who use Dropbox Encore)
