### PR TITLE
added support for fontcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Improved the configuration loader engine
+- Added support for Fontcase (thx @vitorgalvao)
 
 ## Mackup 0.7
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Filezilla](https://filezilla-project.org/)
   - [Fish](http://ridiculousfish.com/shell/)
   - [Flux](http://stereopsis.com/flux/)
+  - [Fontcase](http://bohemiancoding.tumblr.com/post/65603011680/retiring-fontcase)
   - [FontExplorer X](http://www.fontexplorerx.com/)
   - [ForkLift 2](http://www.binarynights.com/forklift/)
   - [GeekTool](http://projects.tynsoe.org/en/geektool/)

--- a/mackup/applications/fontcase.cfg
+++ b/mackup/applications/fontcase.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Fontcase
+
+[configuration_files]
+Library/Containers/com.bohemiancoding.fontcase/Data/Library/Preferences/com.bohemiancoding.fontcase.plist


### PR DESCRIPTION
No long under development, but still one of the best at what it does.

Since it’s under `Library/Containers`, this probably should wait until `mackup` adds support for that.