### PR TITLE
Limit .vim folder backup for better linux support

### DIFF
--- a/mackup/applications/vim.cfg
+++ b/mackup/applications/vim.cfg
@@ -5,7 +5,8 @@ name = Vim
 .gvimrc
 .gvimrc.before
 .gvimrc.after
-.vim
+.vim/autoload
+.vim/colors
 .vimrc
 .vimrc.before
 .vimrc.after


### PR DESCRIPTION
The .vim directory as a whole should not sync, because it contains the bundle directory which may have bundles that are compiled specific to a platform. This will break down when syncing across architectures (Mac / Linux). Instead we should only sync the containing directors other than bundles. Bundles can be easily reinstalled on a new platform with a plugin manager like vundle.
