### PR TITLE
Error messages display in a red color to improve readablity

### DIFF
--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -172,7 +172,9 @@ def error(message):
     Args:
         message(str): The message to display.
     """
-    sys.exit("Error: {}".format(message))
+    fail = '\033[91m'
+    end = '\033[0m'
+    sys.exit(fail + "Error: {}".format(message) + end)
 
 
 def parse_cmdline_args():


### PR DESCRIPTION
I found it slightly annoying when the only way to indicate Mackup had encountered an error was a small normal-coloured error message that was easily lost amongst the other text. So, here are error messages in red:

![2014-04-10-115603_1280x800_scrot](https://cloud.githubusercontent.com/assets/3515754/2670725/5e9c321a-c0d1-11e3-8388-fe6dfee1f1e8.png)
