### PR TITLE
NValt: stop backing up notes from "Notational Data"

### DIFF
--- a/mackup/applications/nvalt.cfg
+++ b/mackup/applications/nvalt.cfg
@@ -4,4 +4,3 @@ name = nvALT
 [configuration_files]
 Library/Preferences/net.elasticthreads.nv.plist
 Library/Application Support/Notational Velocity
-Library/Application Support/Notational Data


### PR DESCRIPTION
When using the single database option, all the notes are stored in "~/Library/Application Support/Notational Data/Notes & Settings".
Notational Velocity already uses Simplenote to sync notes.
