### PR TITLE
Corrects path to Divvy plist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Support for Keybase
+- More support for Divvy (via @oalders)
 
 ## Mackup 0.7.2
 

--- a/mackup/applications/divvy.cfg
+++ b/mackup/applications/divvy.cfg
@@ -3,3 +3,4 @@ name = Divvy
 
 [configuration_files]
 Library/Preferences/com.mizage.direct.Divvy.plist
+Library/Preferences/com.mizage.Divvy.plist


### PR DESCRIPTION
Syncing with Divvy 1.3.8 on 10.9 and 10.7
