### PR TITLE
Adds bundle directory to vim config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Support for Tig (via @damiankloip)
+- Added bundle directory to vim config (via @alanlamielle)
 
 ## Mackup 0.7.3
 

--- a/mackup/applications/vim.cfg
+++ b/mackup/applications/vim.cfg
@@ -7,6 +7,7 @@ name = Vim
 .gvimrc.after
 .vim/autoload
 .vim/colors
+.vim/bundle
 .vimrc
 .vimrc.before
 .vimrc.after


### PR DESCRIPTION
The 'bundle' directory in ~/.vim/ is used by both the Pathogen and Vundle plugin
managers for vim.

I see that commit ddc4f87e50f5 removed full .vim/ backup support, so this commit adds explicit support for a popular subdirectory in .vim/.
