### PR TITLE
Add more vim folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Added doc, ftdetect, ftplugin, indent, syntax directories to vim config
+  (via @feigaochn)
 - Support for Tig (via @damiankloip)
 - Added bundle directory to vim config (via @alanlamielle)
 

--- a/mackup/applications/vim.cfg
+++ b/mackup/applications/vim.cfg
@@ -6,8 +6,13 @@ name = Vim
 .gvimrc.before
 .gvimrc.after
 .vim/autoload
-.vim/colors
 .vim/bundle
+.vim/colors
+.vim/doc
+.vim/ftdetect
+.vim/ftplugin
+.vim/indent
+.vim/syntax
 .vimrc
 .vimrc.before
 .vimrc.after


### PR DESCRIPTION
Add more folders of `.vim` where users likely to store their own scripts instead of those vundled/pathogened ones.

PS. Regarding `.vim/bundle` folder, #234 removed it from `vim.cfg`, but #268 had just added it back. I suggest to make a separate `vim-bundle` config.