### PR TITLE
Atom syncs only config data, excluding cache files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Mackup Changelog
 
 ## WIP
-
+- Atom now only syncs essential files, excluding compiled and cache folders (via @lmartins)
 - Support for Artistic Style (via @feigaochn)
 - Support for Tig (via @damiankloip)
 - Added bundle directory to vim config (via @alanlamielle)

--- a/mackup/applications/atom.cfg
+++ b/mackup/applications/atom.cfg
@@ -4,4 +4,10 @@ name = Atom
 [configuration_files]
 
 Library/Preferences/com.github.atom.plist
-.atom
+.atom/config.cson
+.atom/init.coffee
+.atom/keymap.cson
+.atom/keymaps
+.atom/packages
+.atom/snippets.cson
+.atom/styles.less


### PR DESCRIPTION
As discussed in https://github.com/lra/mackup/issues/246#issuecomment-47555935, updated Atom configuration to only include files relevant to the workstation config, excluding files generated at runtime that were also contributing to heavy long Dropbox sync processes.
