### PR TITLE
Removed `Library/Preferences/com.apple.iChat.plist` from messages.cfg

### DIFF
--- a/mackup/applications/messages.cfg
+++ b/mackup/applications/messages.cfg
@@ -3,7 +3,6 @@ name = Messages
 
 [configuration_files]
 Library/Application Scripts/com.apple.iChat
-Library/Preferences/com.apple.iChat.plist
 Library/Preferences/com.apple.iChat.AIM.plist
 Library/Preferences/com.apple.iChat.Jabber.plist
 Library/Preferences/com.apple.iChat.LSSharedFileList.plist


### PR DESCRIPTION
Closes #286.

This file seems to store information about the current state, so there should be no harm in removing it.
