### PR TITLE
Refine ssh config: no need to backup keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Improved support for Stata (via @kfinlay)
 - Improved Messages support (via @vitorgalvao)
 - Support for Seil and moved PCKeyboardHack there (via @kfinlay)
+- Improved support for ssh, excluding any the credential keys (via @nkcfan)
 
 ## Mackup 0.7.3
 

--- a/mackup/applications/ssh.cfg
+++ b/mackup/applications/ssh.cfg
@@ -2,4 +2,5 @@
 name = SSH
 
 [configuration_files]
-.ssh
+.ssh/config
+.ssh/authorized_keys


### PR DESCRIPTION
It is safer to prevent any the credential keys shared or backed up. Normally if computer changed, the user should generate new keys instead of reusing existing ones.