### PR TITLE
Add support for Xcode templates

### DIFF
--- a/mackup/applications/xcode.cfg
+++ b/mackup/applications/xcode.cfg
@@ -6,3 +6,4 @@ Library/Developer/Xcode/UserData/CodeSnippets
 Library/Developer/Xcode/UserData/FontAndColorThemes
 Library/Developer/Xcode/UserData/KeyBindings
 Library/Developer/Xcode/UserData/SearchScopes.xcsclist
+Library/Developer/Xcode/Templates


### PR DESCRIPTION
Users can create custom templates for use in the Xcode New File dialog. This will also back up those.
