### PR TITLE
added VLC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Support for Seil and moved PCKeyboardHack there (via @kfinlay)
 - Improved support for curl (via @nkcfan)
 - Improved support for fish (via @nanoxd)
+- Added support for VLC (via @kiliankoe)
 
 ## Mackup 0.7.3
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Vim](http://www.vim.org/)
   - [Vimperator](http://www.vimperator.org/vimperator)
   - [Viscosity](http://www.sparklabs.com/viscosity/)
+  - [VLC](http://www.videolan.org/index.html)
   - [Wget](https://www.gnu.org/software/wget/)
   - [Witch](http://manytricks.com/witch/)
   - [X11](http://www.x.org/)

--- a/mackup/applications/vlc.cfg
+++ b/mackup/applications/vlc.cfg
@@ -1,0 +1,8 @@
+[application]
+name = VLC
+
+[configuration_files]
+Library/Application Support/org.videolan.vlc
+Library/Preferences/org.videolan.vlc
+Library/Preferences/org.videolan.vlc.LSSharedFileList.plist
+Library/Preferences/org.videolan.vlc.plist


### PR DESCRIPTION
I would've thought it to be relatively straight-forward to add an application, but this is erroring out for me. Anybody know why?

```
Traceback (most recent call last):
  File "/usr/local/bin/mackup", line 26, in <module>
    mackup.main.main()
  File "/usr/local/Cellar/mackup/0.7.3/lib/python2.7/site-packages/mackup/main.py", line 47, in main
    app = ApplicationProfile(mckp, app_db.get_files(app_name))
  File "/usr/local/Cellar/mackup/0.7.3/lib/python2.7/site-packages/mackup/appsdb.py", line 106, in get_files
    return self.apps[name]['configuration_files']
KeyError: 'vlc'
```

If it's something I can fix, I'll gladly do so before this is merged.