### PR TITLE
improved support for Slate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Mackup Changelog
 
 ## WIP
+- Improved support for Slate (via @bradcerasani)
 - Added support for nvpy - a Linux client for SimpleNote (via @hiyer)
 - Atom now only syncs essential files, excluding compiled and cache folders (via @lmartins)
 - Support for Artistic Style (via @feigaochn)

--- a/mackup/applications/slate.cfg
+++ b/mackup/applications/slate.cfg
@@ -3,4 +3,5 @@ name = Slate
 
 [configuration_files]
 .slate
+.slate.js
 Library/Application Support/com.slate.Slate


### PR DESCRIPTION
Slate supports two types of config files: `.slate` and `.slate.js`. Currently Mackup only supports `.slate` - this patch adds support for `.slate.js`.

More on `.slate.js` config [here](https://github.com/jigish/slate/wiki/JavaScript-Configs).
