### PR TITLE
bash: also include .aliases in backup

### DIFF
--- a/mackup/applications/bash.cfg
+++ b/mackup/applications/bash.cfg
@@ -2,6 +2,7 @@
 name = Bash
 
 [configuration_files]
+.aliases
 .bash_aliases
 .bash_logout
 .bashrc


### PR DESCRIPTION
I (as many others) use `.aliases` instead of `.bash_aliases` so I included it to the config files