### PR TITLE
Adds .vim/ftplugin to vim config

### DIFF
--- a/mackup/applications/vim.cfg
+++ b/mackup/applications/vim.cfg
@@ -8,6 +8,7 @@ name = Vim
 .vim/autoload
 .vim/colors
 .vim/bundle
+.vim/ftplugin
 .vimrc
 .vimrc.before
 .vimrc.after


### PR DESCRIPTION
Sync the ftplugin directory under .vim so that language-specific configs
can be synced with mackup.
