### PR TITLE
backup digrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Support for Houdini (via @kfinlay)
+- Support for dig (via @glaszig)
 
 ## Mackup 0.7.4
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Dash](http://kapeli.com/dash)
   - [Deal Alert](http://dealalertapp.com/)
   - [Default Folder X](http://www.stclairsoft.com/DefaultFolderX/)
+  - [Dig](http://en.wikipedia.org/wiki/Dig_(command))
   - [Divvy](http://mizage.com/divvy/)
   - [Dolphin](https://dolphin-emu.org/)
   - [Droplr](https://droplr.com/hello)

--- a/mackup/applications/dig.cfg
+++ b/mackup/applications/dig.cfg
@@ -1,0 +1,5 @@
+[application]
+name = dig
+
+[configuration_files]
+.digrc


### PR DESCRIPTION
this adds support for [dig](http://en.wikipedia.org/wiki/Dig_(command)) and backs up the `~/.digrc`.