### PR TITLE
Specify the full filepath getting backed up

### DIFF
--- a/mackup/application.py
+++ b/mackup/application.py
@@ -56,7 +56,7 @@ class ApplicationProfile(object):
                               or os.path.isdir(mackup_filepath))
                          and os.path.samefile(filepath, mackup_filepath))):
 
-                print "Backing up {}...".format(filename)
+                print "Backing up {} ...".format(filepath)
 
                 # Check if we already have a backup
                 if os.path.exists(mackup_filepath):


### PR DESCRIPTION
It would be more useful to see the full filepath being backed up
including the home directory. This allows you to copy and paste the file
into the Terminal to open or edit it, and in iTerm2 you can command
click on a path to open it directly.