### PR TITLE
Update path to latest Textual plist file location.

### DIFF
--- a/mackup/applications/textual.cfg
+++ b/mackup/applications/textual.cfg
@@ -4,4 +4,4 @@ name = Textual
 [configuration_files]
 Library/Application Support/Textual IRC
 Library/Preferences/com.codeux.irc.textual.plist
-Library/Containers/com.codeux.irc.textual
+Library/Containers/com.codeux.irc.textual/Data/Library/Preferences/com.codeux.irc.textual.plist


### PR DESCRIPTION
Fixes #356.

A change introduced via issue #258 results in mackup following container symlinks created by Textual that lead to the users Desktop and Downloads folders, as well as various media folders. As such, mackup will try to handle backup of potentially large amounts of data that are outside the scope of the application.

This fix updates the application config file to use the full path to the (potentially cached) Textual plist file.

See http://www.codeux.com/textual/wiki/Frequently-Asked-Questions.wiki#faq-entry-14 for reference.
