### PR TITLE
Add support for rubocop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 
+- Support for Rubocop (via @iainbeeston)
 - Support for Terminator (via @chr1sbest)
 - Support for Houdini (via @kfinlay)
 - Support for IntelliJ IDEA 13 (via @dsager)

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Rails](http://rubyonrails.org/)
   - [rTorrent](http://libtorrent.rakshasa.no/)
   - [R](http://www.r-project.org/)
+  - [Rubocop](https://github.com/bbatsov/rubocop)
   - [Ruby Version](https://gist.github.com/fnichol/1912050)
   - [Ruby](http://ruby-lang.org/)
   - [RubyMine](http://www.jetbrains.com/ruby/)

--- a/mackup/applications/rubocop.cfg
+++ b/mackup/applications/rubocop.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Rubocop
+
+[configuration_files]
+.rubocop.yml


### PR DESCRIPTION
Rubocop is a code linter for ruby. It has a single config file (`.rubocop.yml`) in the home directory.

The homepage for rubocop is here:

https://github.com/bbatsov/rubocop
