### PR TITLE
Added support for VPN Tracker 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Support for IntelliJ IDEA 13 (via @dsager)
 - Support for Pass (via @kykim)
 - Support for Composer (via @fayland)
+- Support for Vpn Tracker 8 (via @davidodere)
 
 ## Mackup 0.7.4
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Vim](http://www.vim.org/)
   - [Vimperator](http://www.vimperator.org/vimperator)
   - [Viscosity](http://www.sparklabs.com/viscosity/)
+  - [Vpn Tracker 8](http://www.vpntracker.com/)
   - [Wget](https://www.gnu.org/software/wget/)
   - [Witch](http://manytricks.com/witch/)
   - [X11](http://www.x.org/)

--- a/mackup/applications/vpn-tracker-8
+++ b/mackup/applications/vpn-tracker-8
@@ -4,5 +4,3 @@ name = Vpn Tracker 8
 [configuration_files]
 Library/Application Support/VPN Tracker 8
 Library/Preferences/com.equinux.VPNTracker8.plist
-~/Library/Application Support/VPN Tracker 8
-~/Library/Preferences/com.equinux.VPNTracker8.plist


### PR DESCRIPTION
This adds support for VPN Tracker 8. According to there docs the config files are stored in 4 different places:

If you want to make a file-system level backup, you can find your VPN connections and related settings in the folder
/Library/Application Support/VPN Tracker 8
Your Secure Desktop(s) are stored in the folder
~/Library/Application Support/VPN Tracker 8
Your preferences are located in the files
/Library/Preferences/com.equinux.VPNTracker8.plist
~/Library/Preferences/com.equinux.VPNTracker8.plist
Please make sure you include these two folders and the two preferences files in all your backups.
