### PR TITLE
Fix application config file precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Support for OsX Stickies (via @djabbz)
 - Support for Navicat Database GUI tools (via @tdm00)
 - Sublime Text 3 now only syncs essential files, excluding session and cache folders
+- Fixed custom application config precedence (via @jalaziz)
 
 ## Mackup 0.7.4
 

--- a/mackup/appsdb.py
+++ b/mackup/appsdb.py
@@ -68,16 +68,16 @@ class ApplicationsDatabase(object):
         custom_apps_dir = os.path.join(os.environ['HOME'], CUSTOM_APPS_DIR)
 
         # Build the list of stock application config files
-        config_files = set()
+        config_files = list()
         for filename in os.listdir(apps_dir):
             if filename.endswith('.cfg'):
-                config_files.add(os.path.join(apps_dir, filename))
+                config_files.append(os.path.join(apps_dir, filename))
 
         # Append the list of custom application config files
         if os.path.isdir(custom_apps_dir):
             for filename in os.listdir(custom_apps_dir):
                 if filename.endswith('.cfg'):
-                    config_files.add(os.path.join(custom_apps_dir,
+                    config_files.append(os.path.join(custom_apps_dir,
                                                   filename))
         return config_files
 


### PR DESCRIPTION
The docs mention that a custom application config file would overwrite a stock config file. However, using a `set` won't guarantee this behavior. Using a `list` would force the custom config files to be parsed after the stock ones.