### PR TITLE
Added support for WebStorm 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Support for ColorSchemer Studio 2 (via @iloveitaly)
 - Support for Billings Pro Server Admin (via @iloveitaly)
 - Support for iStat Menus 5 (via @jverdeyen)
+- Support for WebStorm 9 (via @inxilpro)
 
 ## Mackup 0.7.4
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Vim](http://www.vim.org/)
   - [Vimperator](http://www.vimperator.org/vimperator)
   - [Viscosity](http://www.sparklabs.com/viscosity/)
+  - [WebStorm 9](https://www.jetbrains.com/webstorm/)
   - [Wget](https://www.gnu.org/software/wget/)
   - [Witch](http://manytricks.com/witch/)
   - [X11](http://www.x.org/)

--- a/mackup/applications/webstorm-9.cfg
+++ b/mackup/applications/webstorm-9.cfg
@@ -1,0 +1,6 @@
+[application]
+name = WebStorm 9
+
+[configuration_files]
+Library/Application Support/WebStorm9
+Library/Preferences/WebStorm9


### PR DESCRIPTION
Virtually the same as existing IntelliJ config files… just with the WebStorm-specific directory names.
