### PR TITLE
fix st3 to only sync essential files, excluding cache, session, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Support for Scroll Reverser (via @ponychicken)
 - Support for JuliaLang (via @danielsuo)
 - Support for OsX Stickies (via @djabbz)
+- Sublime Text 3 now only syncs essential files, excluding session and cache folders
 
 ## Mackup 0.7.4
 

--- a/mackup/applications/sublime-text-3.cfg
+++ b/mackup/applications/sublime-text-3.cfg
@@ -3,4 +3,5 @@ name = Sublime Text 3
 
 [configuration_files]
 Library/Application Support/Sublime Text 3/Packages/User
-.config/sublime-text-3
+.config/sublime-text-3/Installed Packages
+.config/sublime-text-3/Packages


### PR DESCRIPTION
Sublime Text 3 configuration was syncing the entire config folder, which includes files that are essentially "local", like session information, cache, backups, etc. This PR fixes that on Linux.
