### PR TITLE
Update README.md, mention mackup.cfg at the top

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,5 +1,7 @@
 # Configuration
 
+All the configuration is done into a file named `.mackup.cfg` to store at the root of your home folder.
+
 ## Storage
 
 ### Dropbox


### PR DESCRIPTION
As new user of mackup, I was wondering how to specify Google Drive as storing engine. The instructions are clear how to setup it, however, the mention of the name of the config file (`~/.mackup.cfg`) are done in other sections at the end of the README.
