### PR TITLE
Sync .psqlrc

### DIFF
--- a/mackup/applications/pgsql.cfg
+++ b/mackup/applications/pgsql.cfg
@@ -3,3 +3,4 @@ name = PostgreSQL
 
 [configuration_files]
 .pgpass
+.psqlrc


### PR DESCRIPTION
The .psqlrc file can be used to customize the psql prompt. See http://www.postgresql.org/docs/9.3/static/app-psql.html#AEN88717 for more information.
