### PR TITLE
Update sublime-text-3.cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Support for OsX Stickies (via @djabbz)
 - Support for Navicat Database GUI tools (via @tdm00)
 - Sublime Text 3 now only syncs essential files, excluding session and cache folders
+- Sublime Text 3 syncs installed plugins
 - Support for ProxyChains & ProxyChains NG (via @mttrb)
 
 ## Mackup 0.7.4

--- a/mackup/applications/sublime-text-3.cfg
+++ b/mackup/applications/sublime-text-3.cfg
@@ -2,6 +2,5 @@
 name = Sublime Text 3
 
 [configuration_files]
-Library/Application Support/Sublime Text 3/Packages/User
-.config/sublime-text-3/Installed Packages
-.config/sublime-text-3/Packages
+Library/Application Support/Sublime Text 3/Packages
+Library/Application Support/Sublime Text 3/Installed Packages

--- a/mackup/applications/sublime-text-3.cfg
+++ b/mackup/applications/sublime-text-3.cfg
@@ -4,3 +4,5 @@ name = Sublime Text 3
 [configuration_files]
 Library/Application Support/Sublime Text 3/Packages
 Library/Application Support/Sublime Text 3/Installed Packages
+.config/sublime-text-3/Packages
+.config/sublime-text-3/Installed Packages


### PR DESCRIPTION
- Backup `Packages` and `Installed Packages` folders which allow user to fully restore not only configuration but also plugins

- Remove `.config/sublime-text-3` references since they are not listed in the documentation
  (http://www.sublimetext.com/docs/3/settings.html)