### PR TITLE
100 % test coverage for config tests

### DIFF
--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -184,3 +184,6 @@ class TestConfig(unittest.TestCase):
                                         'sublime-text-3',
                                         'x11',
                                         'vim'])
+
+    def test_config_old_config(self):
+        self.assertRaises(SystemExit, Config, 'mackup-old-config.cfg')

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -13,6 +13,12 @@ class TestConfig(unittest.TestCase):
         realpath = os.path.dirname(os.path.realpath(__file__))
         os.environ['HOME'] = os.path.join(realpath, 'fixtures')
 
+    def test_config_no_config(self):
+        cfg = Config()
+
+        # Should should do the same as the default, empty configuration
+        self.test_config_empty()
+
     def test_config_empty(self):
         cfg = Config('mackup-empty.cfg')
 

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -17,7 +17,20 @@ class TestConfig(unittest.TestCase):
         cfg = Config()
 
         # Should should do the same as the default, empty configuration
-        self.test_config_empty()
+        assert isinstance(cfg.engine, str)
+        assert cfg.engine == ENGINE_DROPBOX
+
+        assert isinstance(cfg.path, str)
+        assert cfg.path == u'/home/some_user/Dropbox'
+
+        assert isinstance(cfg.directory, str)
+        assert cfg.directory == u'Mackup'
+
+        assert isinstance(cfg.fullpath, str)
+        assert cfg.fullpath == u'/home/some_user/Dropbox/Mackup'
+
+        assert cfg.apps_to_ignore == set()
+        assert cfg.apps_to_sync == set()
 
     def test_config_empty(self):
         cfg = Config('mackup-empty.cfg')

--- a/tests/fixtures/mackup-old-config.cfg
+++ b/tests/fixtures/mackup-old-config.cfg
@@ -1,0 +1,15 @@
+[storage]
+engine = file_system
+path = /some/absolute/folder
+directory = custom_folder
+
+[applications_to_ignore]
+subversion
+sequel-pro
+
+[Allowed Applications]
+ssh
+git
+
+[Ignored Applications]
+vim


### PR DESCRIPTION
Added tests for when there is an old config (which throws a `SystemExit` exception) and for when there is no config file present (which should do the same thing as a default configuration file)

Proof: 
![test-coverage](https://cloud.githubusercontent.com/assets/3515754/6045090/75579fd2-ac65-11e4-88af-b461e6184474.png)
