### PR TITLE
Utils.py tests - 97% coverage

### DIFF
--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -280,8 +280,8 @@ class TestMackup(unittest.TestCase):
        convert_to_octal(nested_dir) == "700"
 
        # Use an "unsupported file type". In this case, /dev/null
-       assert os.path.exists("/dev/null")
-       self.assertRaises(ValueError, utils.chmod, "/dev/null")
+       dev_null = open(os.devnull, 'wb')
+       self.assertRaises(ValueError, utils.chmod, dev_null)
 
     def test_error(self):
         test_string = "Hello World"
@@ -290,6 +290,8 @@ class TestMackup(unittest.TestCase):
                          test_string)
 
     def test_parse_cmdline_args(self):
+        # /dev/null to throwaway the error
+        dev_null = open(os.devnull, 'wb')
         modes = [utils.constants.BACKUP_MODE,
                  utils.constants.RESTORE_MODE,
                  utils.constants.UNINSTALL_MODE,
@@ -302,6 +304,7 @@ class TestMackup(unittest.TestCase):
 
         # Change the command line arguments to have an incorrect mode
         utils.sys.argv = ["the_program", "some wrong mode"]
+        utils.sys.stderr = dev_null
         self.assertRaises(SystemExit, utils.parse_cmdline_args)
 
     def test_failed_backup_location(self):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -337,14 +337,13 @@ class TestMackup(unittest.TestCase):
         path = "some/file"
 
         # Force the Mac OSX Test using lambda magic
-        utils.system = lambda _: utils.constants.PLATFORM_DARWIN
+        utils.platform.system = lambda *args: utils.constants.PLATFORM_DARWIN
         assert utils.can_file_be_synced_on_current_platform(path)
 
         # Force the Linux Test using lambda magic
-        utils.system = lambda _: utils.constants.PLATFORM_LINUX
+        utils.platform.system = lambda *args: utils.constants.PLATFORM_LINUX
         assert utils.can_file_be_synced_on_current_platform(path)
 
         # Try to use the library path on Linux, which shouldn't work
         path = os.path.join(os.environ["HOME"], "Library/")
-        print(path)
         assert not utils.can_file_be_synced_on_current_platform(path)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -30,6 +30,13 @@ class TestMackup(unittest.TestCase):
         utils.raw_input = custom_raw_input
         assert not utils.confirm('Answer No to this question')
 
+    def test_confirm_python3(self):
+        # Override the raw_input used in utils
+        def custom_raw_input(_):
+            raise NameError
+        # Also override input used in utils, because
+        utils.raw_input = custom_raw_input
+
     def test_confirm_typo(self):
         # Override the raw_input used in utils
         def custom_raw_input(_):
@@ -281,6 +288,21 @@ class TestMackup(unittest.TestCase):
         self.assertRaises(SystemExit,
                          utils.error,
                          test_string)
+
+    def test_parse_cmdline_args(self):
+        modes = [utils.constants.BACKUP_MODE,
+                 utils.constants.RESTORE_MODE,
+                 utils.constants.UNINSTALL_MODE,
+                 utils.constants.LIST_MODE]
+
+        for mode in modes:
+            # Change the command line arguments to contain the correct mode
+            utils.sys.argv = ["the_program", mode]
+            assert str(utils.parse_cmdline_args()) == "Namespace(mode='%s')" %mode
+
+        # Change the command line arguments to have an incorrect mode
+        utils.sys.argv = ["the_program", "some wrong mode"]
+        self.assertRaises(SystemExit, utils.parse_cmdline_args)
 
     def test_failed_backup_location(self):
         """

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -169,6 +169,44 @@ class TestMackup(unittest.TestCase):
         utils.delete(srcpath)
         utils.delete(dstpath)
 
+    def test_copy_dir(self):
+        """
+        Copies a directory recursively to the destination path
+        """
+        # Create a tmp folder
+        srcpath = tempfile.mkdtemp()
+
+        # Create a tmp file
+        tf = tempfile.NamedTemporaryFile(delete=False, dir=srcpath)
+        srcfile = tf.name
+        tf.close()
+
+        # Create a tmp folder
+        dstpath = tempfile.mkdtemp()
+
+        # Set the destination filename
+        srcpath_basename = os.path.basename(srcpath)
+        dstfile = os.path.join(dstpath,
+                               srcpath_basename,
+                               os.path.basename(srcfile))
+        # Make sure the source file and destination folder exist and the
+        # destination file doesn't yet exist
+        assert os.path.isdir(srcpath)
+        assert os.path.isfile(srcfile)
+        assert os.path.isdir(dstpath)
+        assert not os.path.exists(dstfile)
+
+        # Check if mackup can copy it
+        utils.copy(srcpath, dstfile)
+        assert os.path.isdir(srcpath)
+        assert os.path.isfile(srcfile)
+        assert os.path.isdir(dstpath)
+        assert os.path.exists(dstfile)
+
+        # Let's clean up
+        utils.delete(srcpath)
+        utils.delete(dstpath)
+
     def test_link_file(self):
         # Create a tmp file
         tf = tempfile.NamedTemporaryFile(delete=False)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -130,7 +130,10 @@ class TestMackup(unittest.TestCase):
         utils.delete(srcfile)
         utils.delete(dstpath)
 
-    def test_copy_dir(self):
+    def test_copy_file_to_dir(self):
+        """
+        Copies a file to a destination folder that already exists
+        """
         # Create a tmp folder
         srcpath = tempfile.mkdtemp()
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -280,8 +280,7 @@ class TestMackup(unittest.TestCase):
        convert_to_octal(nested_dir) == "700"
 
        # Use an "unsupported file type". In this case, /dev/null
-       dev_null = open(os.devnull, 'wb')
-       self.assertRaises(ValueError, utils.chmod, dev_null)
+       self.assertRaises(ValueError, utils.chmod, os.devnull)
 
     def test_error(self):
         test_string = "Hello World"

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -281,3 +281,26 @@ class TestMackup(unittest.TestCase):
         self.assertRaises(SystemExit,
                          utils.error,
                          test_string)
+
+    def test_failed_backup_location(self):
+        """
+        Tests for the error that should occur if the backup folder cannot be found
+        for Dropbox, Google, and Copy
+        """
+        # Hack to make our home folder some temporary folder
+        temp_home = tempfile.mkdtemp()
+        utils.os.environ['HOME'] = temp_home
+
+        # Check for the missing Dropbox folder
+        assert not os.path.exists(os.path.join(temp_home, ".dropbox/host.db"))
+        self.assertRaises(SystemExit, utils.get_dropbox_folder_location)
+
+        # Check for the missing Google Drive folder
+        assert not os.path.exists(os.path.join(temp_home,
+            "Library/Application Support/Google/Drive/sync_config.db"))
+        self.assertRaises(SystemExit, utils.get_google_drive_folder_location)
+
+        # Check for the missing Copy Folder
+        assert not os.path.exists(os.path.join(temp_home,
+            "Library/Application Support/Copy Agent/config.db"))
+        self.assertRaises(SystemExit, utils.get_copy_folder_location)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -304,3 +304,8 @@ class TestMackup(unittest.TestCase):
         assert not os.path.exists(os.path.join(temp_home,
             "Library/Application Support/Copy Agent/config.db"))
         self.assertRaises(SystemExit, utils.get_copy_folder_location)
+
+    def test_is_process_running(self):
+        # A pgrep that has one letter and a wildcard will always return id 1
+        assert utils.is_process_running("a*")
+        assert not utils.is_process_running("some imaginary process")

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -309,3 +309,20 @@ class TestMackup(unittest.TestCase):
         # A pgrep that has one letter and a wildcard will always return id 1
         assert utils.is_process_running("a*")
         assert not utils.is_process_running("some imaginary process")
+
+    def test_can_file_be_synced_on_current_platform(self):
+        # Any file path will do, even if it doesn't exist
+        path = "some/file"
+
+        # Force the Mac OSX Test using lambda magic
+        utils.system = lambda _: utils.constants.PLATFORM_DARWIN
+        assert utils.can_file_be_synced_on_current_platform(path)
+
+        # Force the Linux Test using lambda magic
+        utils.system = lambda _: utils.constants.PLATFORM_LINUX
+        assert utils.can_file_be_synced_on_current_platform(path)
+
+        # Try to use the library path on Linux, which shouldn't work
+        path = os.path.join(os.environ["HOME"], "Library/")
+        print(path)
+        assert not utils.can_file_be_synced_on_current_platform(path)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -275,3 +275,9 @@ class TestMackup(unittest.TestCase):
        # Use an "unsupported file type". In this case, /dev/null
        assert os.path.exists("/dev/null")
        self.assertRaises(ValueError, utils.chmod, "/dev/null")
+
+    def test_error(self):
+        test_string = "Hello World"
+        self.assertRaises(SystemExit,
+                         utils.error,
+                         test_string)


### PR DESCRIPTION
These are tests for most of the functions in Utils.py. I wasn't able to get to `remove_acl` or `remove_immutable_attribute` because I could not find an elegant way to do that across operating systems without resorting to using `subprocess.call`.