### PR TITLE
Adding support for Photoshop CC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Added support for Photoshop CC (@ponychicken)
+
 ## Mackup 0.8.3
 
 - Remove the scripts dir from Messages syncing (@vitorgalvao)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Adium](http://adium.im/)
   - [Adobe Camera Raw](http://www.adobe.com/products/photoshop/extend.html)
   - [Adobe Lightroom](http://www.adobe.com/products/photoshop-lightroom.html)
+  - [Adobe Photoshop CC](http://www.adobe.com/products/photoshop.html)
   - [AppCode](http://www.jetbrains.com/objc/)
   - [aria2c](http://aria2.sourceforge.net/)
   - [Arara](http://cereda.github.io/arara/)

--- a/mackup/applications/photoshop.cfg
+++ b/mackup/applications/photoshop.cfg
@@ -1,0 +1,9 @@
+[application]
+name = Adobe Photoshop
+
+[configuration_files]
+Library/Application Support/Adobe/Adobe Photoshop CC 2013/Presets
+Library/Application Support/Adobe/Adobe Photoshop CC 2014/Presets
+Library/Preferences/Adobe Photoshop CC 2013 Settings
+Library/Preferences/Adobe Photoshop CC 2014 Settings
+Library/Preferences/com.adobe.Photoshop.plist


### PR DESCRIPTION
This is split up into two cfg files: Adobe releases about one major version of Photoshop per year. The major versions each use a new set of Preference folders. I think it's best to have one cfg per version, but it would be also possible to put them all in one. Thoughts?