### PR TITLE
sublime-text-3: Sync only User folder on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added support for PyCharm 4 (via @fcvarela)
 - Added support for Popcorn Time (via @JacopKane)
+- Sublime Text 3 syncs only Packages/User directory on Linux
 
 ## Mackup 0.8.3
 

--- a/mackup/applications/sublime-text-3.cfg
+++ b/mackup/applications/sublime-text-3.cfg
@@ -3,5 +3,4 @@ name = Sublime Text 3
 
 [configuration_files]
 Library/Application Support/Sublime Text 3/Packages/User
-.config/sublime-text-3/Installed Packages
-.config/sublime-text-3/Packages
+.config/sublime-text-3/Packages/User


### PR DESCRIPTION
As I have commented in https://github.com/lra/mackup/pull/415#issuecomment-76547492, only `Packages/User` folder [should be synced](https://packagecontrol.io/docs/syncing#dropbox-linux), which is the current behaviour on Mac OS X too.