### PR TITLE
Custom themes and plugins support

### DIFF
--- a/mackup/applications/zsh.cfg
+++ b/mackup/applications/zsh.cfg
@@ -7,3 +7,5 @@ name = Zsh
 .zshrc
 .zlogin
 .zlogout
+.zsh/plugins
+.zsh/themes


### PR DESCRIPTION
When using antigen or other zsh plugin managers, custom themes and plugins are found in the `.zsh/themes` and `.zsh/plugins` dir. If not backed up these are lost.
This takes care of that.
Feel free to chime in if you feel this should be done differently.