### PR TITLE
Added -v and --version flag to the command line interface for Mackup

### DIFF
--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -225,6 +225,9 @@ def parse_cmdline_args():
                                  constants.UNINSTALL_MODE,
                                  constants.LIST_MODE],
                         help=help_msg)
+    # Add the optional arg
+    parser.add_argument("-v", "--version", action="version",
+                        version="Mackup {}".format(constants.VERSION))
 
     # Parse the command line and return the parsed options
     return parser.parse_args()


### PR DESCRIPTION
I found it annoying having to use `mackup -h` each time I needed to check the version number, and then having to hunt for it amongst all the other help text. So I just whipped this up so it was easier to compare versions quickly and efficiently. 