### PR TITLE
Added the -f and --force argument to the cmdline parser

### DIFF
--- a/mackup/main.py
+++ b/mackup/main.py
@@ -47,6 +47,10 @@ def main():
     mckp = Mackup()
     app_db = ApplicationsDatabase()
 
+    # If we want to answer mackup with "yes" for each question
+    if args['force']:
+        utils.FORCE_YES = True
+
     if args['backup']:
         # Check the env where the command is being run
         mckp.check_for_usable_backup_env()

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -13,6 +13,7 @@ Usage:
 
 Options:
   -h --help     Show this screen.
+  -f --force    Force every question asked to be answered with "Yes"
   --version     Show version.
 
 Modes of action:

--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -11,6 +11,11 @@ import sqlite3
 from . import constants
 
 
+# Flag that controls how user confirmation works.
+# If True, the user wants to say "yes" to everything.
+FORCE_YES = False
+
+
 def confirm(question):
     """
     Ask the user if he really want something to happen.
@@ -21,6 +26,9 @@ def confirm(question):
     Returns:
         (boolean): Confirmed or not
     """
+    if FORCE_YES:
+        return True
+
     while True:
         # Python 3 check
         if sys.version_info[0] < 3:


### PR DESCRIPTION
I found it annoying to type out "y" or "Yes" each time I re-backed up mackup while I was fiddling around with it, so I added a `-f` and `--force` feature that basically answers "yes" to every question mackup asks. This should be enough to fix issues #283 and #68.