### PR TITLE
Add support for common global gitignores.

### DIFF
--- a/mackup/applications/git.cfg
+++ b/mackup/applications/git.cfg
@@ -4,3 +4,5 @@ name = Git
 [configuration_files]
 .gitconfig
 .config/git/ignore
+.gitignore_global
+.gitignore


### PR DESCRIPTION
Covers both `~/.gitignore_global` and `~/.gitignore`.

The Github instructions for setting a global ignore propose using
`~/.gitignore_global`. Most probably have this.
https://help.github.com/articles/ignoring-files/#create-a-global-gitignore

Another large group probably have simply `~/.gitignore`.
https://robots.thoughtbot.com/global-gitignore