### PR TITLE
Add support for .git-completion.bash

### DIFF
--- a/mackup/applications/git.cfg
+++ b/mackup/applications/git.cfg
@@ -4,3 +4,4 @@ name = Git
 [configuration_files]
 .gitconfig
 .config/git/ignore
+.git-completion.bash


### PR DESCRIPTION
Adds support to backup https://github.com/git/git/blob/master/contrib/completion/git-completion.bash