### PR TITLE
Added support for Spacemacs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added support for Royal TSX (via @amatos)
 - Added support for CotEditor (via @usami-k)
 - Added support for xbindkeys (via @scottames)
+- Added support for Spacemacs (via @x-ji)
 
 ## Mackup 0.8.5
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Slogger](http://brettterpstra.com/projects/slogger/)
   - [Soulver](http://www.acqualia.com/soulver/)
   - [SourceTree](http://sourcetreeapp.com)
+  - [Spacemacs](https://github.com/syl20bnr/spacemacs)
   - [Spark](http://www.shadowlab.org/softwares/spark.php)
   - [Spectrwm](https://opensource.conformal.com/wiki/spectrwm)
   - [Spectacle](http://spectacleapp.com/)

--- a/mackup/applications/spacemacs.cfg
+++ b/mackup/applications/spacemacs.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Spacemacs
+
+[configuration_files]
+.spacemacs


### PR DESCRIPTION
Spacemacs https://github.com/syl20bnr/spacemacs is an Emacs advanced Kit focused on Evil. It modifies `.emacs.d`(which is already backed up in Mackup) but also creates its own dotfile called `.spacemacs` in home folder.