### PR TITLE
don't break textmate's ruby

### DIFF
--- a/mackup/applications/textmate.cfg
+++ b/mackup/applications/textmate.cfg
@@ -2,6 +2,7 @@
 name = TextMate
 
 [configuration_files]
-Library/Application Support/TextMate
+Library/Application Support/TextMate/Global.tmProperties
+Library/Application Support/TextMate/Managed
 Library/Preferences/com.macromates.textmate.plist
 Library/Preferences/com.macromates.textmate.latex_config.plist


### PR DESCRIPTION
TextMate 2's ruby is broken when mackup symlinks it. We can be a bit more selective about what is synced as there are only a few files in Library/Application Support/TextMate. The other files probably don't need to by synced as they are system dependent. Clipboard history, last window configuration. But maybe they could be. The only real problem is syncing the Ruby folder. If there's a way to exclude a file maybe we could use that instead.