### PR TITLE
Copy returns incorrect error

### DIFF
--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -258,7 +258,7 @@ def get_copy_folder_location():
             cur.close()
 
     if not copy_home:
-        error("Unable to find your Google Drive install =(")
+        error("Unable to find your Copy install =(")
 
     return copy_home
 


### PR DESCRIPTION
"Unable to find your Google Drive install =("
replaced with "Unable to find your Copy install =("

although it won't work with Linux anyway.