### PR TITLE
Copy working with Linux

### DIFF
--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -210,6 +210,8 @@ def get_google_drive_folder_location():
 
     Returns:
         (unicode) Full path to the current Google Drive folder
+
+    Still no Google Drive client for Linux so that isn't going to work
     """
     gdrive_db_path = 'Library/Application Support/Google/Drive/sync_config.db'
     googledrive_home = None
@@ -240,7 +242,10 @@ def get_copy_folder_location():
     Returns:
         (unicode) Full path to the current Copy folder
     """
-    copy_settings_path = 'Library/Application Support/Copy Agent/config.db'
+    if platform.system() == CONSTANTS.PLATFORM_DARWIN
+        copy_settings_path = 'Library/Application Support/Copy Agent/config.db'
+    elif platform.system() == CONSTANTS.PLATFORM_LINUX
+        copy_settings_path = '.copy/config.db'
     copy_home = None
 
     copy_settings = os.path.join(os.environ['HOME'], copy_settings_path)

--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -242,9 +242,9 @@ def get_copy_folder_location():
     Returns:
         (unicode) Full path to the current Copy folder
     """
-    if platform.system() == CONSTANTS.PLATFORM_DARWIN:
+    if platform.system() == constants.PLATFORM_DARWIN:
         copy_settings_path = 'Library/Application Support/Copy Agent/config.db'
-    elif platform.system() == CONSTANTS.PLATFORM_LINUX:
+    elif platform.system() == constants.PLATFORM_LINUX:
         copy_settings_path = '.copy/config.db'
     copy_home = None
 

--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -242,9 +242,9 @@ def get_copy_folder_location():
     Returns:
         (unicode) Full path to the current Copy folder
     """
-    if platform.system() == CONSTANTS.PLATFORM_DARWIN
+    if platform.system() == CONSTANTS.PLATFORM_DARWIN:
         copy_settings_path = 'Library/Application Support/Copy Agent/config.db'
-    elif platform.system() == CONSTANTS.PLATFORM_LINUX
+    elif platform.system() == CONSTANTS.PLATFORM_LINUX:
         copy_settings_path = '.copy/config.db'
     copy_home = None
 


### PR DESCRIPTION
Added a if statement to select copy_settings_path based on constants.PLATFORM_DARWIN and constants.PLATFORM_LINUX. Tested on my laptop (Xubuntu 14.10).

As a note, and I don't have a Mac available to test any more, I seem to recall that a lot of cross-platform apps symlink their Application Support files to the corresponding location in $HOME so .copy/config.db might exist and that might not be necessary.

No native Google Drive support for Linux as yet (still) but the same if statement would apply if and when it is released.