### PR TITLE
Python3

### DIFF
--- a/mackup/config.py
+++ b/mackup/config.py
@@ -2,6 +2,7 @@
 
 import os
 import os.path
+import sys
 
 from .constants import (MACKUP_BACKUP_PATH,
                         MACKUP_CONFIG_FILE,
@@ -206,7 +207,11 @@ class Config(object):
                 raise ConfigError("The required 'path' can't be found while"
                                   " the 'file_system' engine is used.")
 
-        return str(path)
+        # Python 2 and python 3 byte strings are different.
+        if sys.version_info[0] < 3:
+            return str(path)
+        else:
+            return path.decode("utf-8")
 
     def _parse_directory(self):
         """

--- a/mackup/config.py
+++ b/mackup/config.py
@@ -209,9 +209,11 @@ class Config(object):
 
         # Python 2 and python 3 byte strings are different.
         if sys.version_info[0] < 3:
-            return str(path)
+            path = str(path)
         else:
-            return path.decode("utf-8")
+            path = path.decode("utf-8")
+
+        return path
 
     def _parse_directory(self):
         """

--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -22,13 +22,12 @@ def confirm(question):
         (boolean): Confirmed or not
     """
     while True:
-        # Python 3 hack
-        try:
-            input = raw_input
-        except NameError:
-            pass
+        # Python 3 check
+        if sys.version_info[0] < 3:
+            answer = raw_input(question + ' <Yes|No>').lower()
+        else:
+            answer = input(question + ' <Yes|No>').lower()
 
-        answer = input(question + ' <Yes|No>').lower()
         if answer == 'yes' or answer == 'y':
             confirmed = True
             break


### PR DESCRIPTION
Python3 strings and input function. I have ```Python 3.4.3 ``` installed using anaconda on my system.
When I ran ```mackup backup```, it gave an error that the Dropbox directory didn't exist which was happening due to the byte string. This pull request takes care of the same.