### PR TITLE
Added support for PyRadio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 
+- Added support for PyRadio (via @joaoponceleao)
 - Added support for Dropzone 3 (via @iansoper)
 - Added support for Autokey (via @danielsuo)
 - Added support for Docker (via @carlossg)

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Punto Switcher](http://punto.yandex.ru/)
   - [PyCharm 4](https://www.jetbrains.com/pycharm/)
   - [PyPI](https://pypi.python.org/pypi)
-  - [PyRadio](https://github.com/coderholic/pyradio)
+  - [PyRadio](http://www.coderholic.com/pyradio/)
   - [Quicksilver](http://qsapp.com/)
   - [Rails](http://rubyonrails.org/)
   - [rTorrent](http://libtorrent.rakshasa.no/)

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Punto Switcher](http://punto.yandex.ru/)
   - [PyCharm 4](https://www.jetbrains.com/pycharm/)
   - [PyPI](https://pypi.python.org/pypi)
+  - [PyRadio](https://github.com/coderholic/pyradio)
   - [Quicksilver](http://qsapp.com/)
   - [Rails](http://rubyonrails.org/)
   - [rTorrent](http://libtorrent.rakshasa.no/)

--- a/mackup/applications/pyradio.cfg
+++ b/mackup/applications/pyradio.cfg
@@ -1,0 +1,5 @@
+[application]
+name = PyRadio
+
+[configuration_files]
+.pyradio/stations.csv


### PR DESCRIPTION
Added support for command line internet radio player PyRadio (https://github.com/coderholic/pyradio).
PyRadio will override the radio stations it provides, with a user provided stations.csv file located at `.pyradio/stations.csv` by default.