### PR TITLE
Taskwarrior Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Add in support for yosemite for google drive (via @seanfreiburg)
+- Added support for taskwarrior (via @ToostInc)
 
 ## Mackup 0.8.6
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
   - [Subversion](http://subversion.apache.org/)
   - [SuperDuper!](http://www.shirt-pocket.com/SuperDuper/SuperDuperDescription.html)
   - [TaskPaper](http://www.hogbaysoftware.com/products/taskpaper)
+  - [Taskwarrior](http://www.taskwarrior.org/)
   - [Teamocil](http://remiprev.github.io/teamocil/)
   - [Terminator](https://launchpad.net/terminator/)
   - [TextMate](http://macromates.com/)

--- a/mackup/applications/taskwarrior.cfg
+++ b/mackup/applications/taskwarrior.cfg
@@ -9,5 +9,5 @@ name = Taskwarrior
 ##
 ## If you'd rather want to sync using mackup, uncomment the following lines.
 
-# .task/backlog.data
+# .task/
 

--- a/mackup/applications/taskwarrior.cfg
+++ b/mackup/applications/taskwarrior.cfg
@@ -1,0 +1,13 @@
+[application]
+name = Taskwarrior
+
+[configuration_files]
+.taskrc
+
+## Note: taskwarrior has it's own sync feature for actual tasks:
+## http://taskwarrior.org/docs/taskserver/setup.html
+##
+## If you'd rather want to sync using mackup, uncomment the following lines.
+
+# .task/backlog.data
+


### PR DESCRIPTION
This adds Taskwarrior support, syncing only the configuration file.

Taskwarrior comes with it's [own syncing capabilities when it comes to the actual tasks](http://taskwarrior.org/docs/taskserver/setup.html), but it might be that users would rather sync those with mackup, if they're syncing their configuration file anyway, hence the commented out section.