### PR TITLE
fix force option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Fixed the 'force' option (via @hiyer)
+
 ## Mackup 0.8.8
 
 - Added support for syncing over Box (via @ninjabong)

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -5,9 +5,9 @@ Copyright (C) 2013-2015 Laurent Raufaste <http://glop.org/>
 
 Usage:
   mackup list
-  mackup backup
-  mackup restore
-  mackup uninstall
+  mackup [ -f | --force ] backup
+  mackup [ -f | --force ] restore
+  mackup [ -f | --force ] uninstall
   mackup (-h | --help)
   mackup --version
 
@@ -49,7 +49,7 @@ def main():
     app_db = ApplicationsDatabase()
 
     # If we want to answer mackup with "yes" for each question
-    if args['force']:
+    if args['--force']:
         utils.FORCE_YES = True
 
     if args['backup']:

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -5,9 +5,9 @@ Copyright (C) 2013-2015 Laurent Raufaste <http://glop.org/>
 
 Usage:
   mackup list
-  mackup [ -f | --force ] backup
-  mackup [ -f | --force ] restore
-  mackup [ -f | --force ] uninstall
+  mackup backup [ -f | --force ]
+  mackup restore [ -f | --force ]
+  mackup uninstall [ -f | --force ] 
   mackup (-h | --help)
   mackup --version
 


### PR DESCRIPTION
Commit 3406a206 broke the restore/backup/uninstall commands because the docopt options were not used properly. Restore, for example, failed with this error:
```
~/s/mackup ❯❯❯ mackup restore                                                                                                                                                                                      
Traceback (most recent call last):
  File "/usr/local/bin/mackup", line 9, in <module>
    load_entry_point('mackup==0.8.8', 'console_scripts', 'mackup')()
  File "/usr/local/lib/python2.7/dist-packages/mackup-0.8.8-py2.7.egg/mackup/main.py", line 52, in main
    if args['force']:
KeyError: 'force'
```
This is because the option is actually received as `--force` and not just `force`:
```
~/s/mackup ❯❯❯ mackup restore
{'--force': False,
 '--help': False,
 '--version': False,
 'backup': False,
 'list': False,
 'restore': True,
 'uninstall': False}
```
There is one change to fix this.
We also need to add the `[ -f | --force ]` option to the commands, because otherwise docopt  does not accept it as valid syntax. For example, if I run `mackup restore -f` without that change, I get this:
```
~/s/mackup ❯❯❯ mackup -f restore
Usage:
  mackup list
  mackup backup
  mackup restore
  mackup uninstall
  mackup (-h | --help)
  mackup --version
```