### PR TITLE
Sync entire Karabiner directory

### DIFF
--- a/mackup/applications/karabiner.cfg
+++ b/mackup/applications/karabiner.cfg
@@ -5,4 +5,4 @@ name = Karabiner
 Library/Preferences/org.pqrs.Karabiner.plist
 Library/Preferences/org.pqrs.Karabiner-AXNotifier.plist
 Library/Preferences/org.pqrs.Karabiner.multitouchextension.plist
-Library/Application Support/Karabiner/private.xml
+Library/Application Support/Karabiner


### PR DESCRIPTION
Right now only `Library/Application Support/Karabiner/private.xml` is backed up. More complex set ups will partition configuration into separate several different xml files, hence I believe it's sane to backup the entire `Library/Application Support/Karabiner` directory.