### PR TITLE
git.cfg XDG support 

### DIFF
--- a/mackup/applications/git.cfg
+++ b/mackup/applications/git.cfg
@@ -3,3 +3,7 @@ name = Git
 
 [configuration_files]
 .gitconfig
+
+[xdg_configuration_files]
+git/config
+git/credentials

--- a/mackup/applications/git.cfg
+++ b/mackup/applications/git.cfg
@@ -6,4 +6,3 @@ name = Git
 
 [xdg_configuration_files]
 git/config
-git/credentials


### PR DESCRIPTION
I would love to also add:
```
[xdg_configuration_files]
git/ignore
```
I know there was some talk about `git/ignore` being overwritten but I have never had that issue when using it from `$XDG_CONFIG_HOME` rather than `~/.config`