### PR TITLE
Add support for MacDive

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [LimeChat](http://limechat.net/mac/)
 - [LittleSnitch](http://www.obdev.at/products/littlesnitch/)
 - [Livestreamer](http://livestreamer.tanuki.se/)
+- [MacDive](http://www.mac-dive.com/)
 - [MacOSX](http://www.apple.com/osx/)
 - [MacVim](https://code.google.com/p/macvim/)
 - [Magic Launch](https://www.oneperiodic.com/products/magiclaunch/)

--- a/mackup/applications/macdive2.cfg
+++ b/mackup/applications/macdive2.cfg
@@ -1,0 +1,6 @@
+[application]
+name = MacDive
+
+[configuration_files]
+Library/Application Support/MacDive
+Library/Preferences/com.mintsoftware.MacDive2.plist


### PR DESCRIPTION
This adds configuration for MacDive (http://www.mac-dive.com/), the digital dive log for Mac OS X.