### PR TITLE
include .vim/vimrc in backup

### DIFF
--- a/mackup/applications/vim.cfg
+++ b/mackup/applications/vim.cfg
@@ -13,6 +13,7 @@ name = Vim
 .vim/ftplugin
 .vim/indent
 .vim/syntax
+.vim/vimrc
 .vimrc
 .vimrc.after
 .vimrc.before


### PR DESCRIPTION
Since Vim 7.4 you can also just place a file vimrc into $HOME/.vim/vimrc and Vim finds it automatically, so this is a potential spot for vimrc