### PR TITLE
Add support for MacDown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add support for MPlayerX (via @digglife)
 - Add support for Day-O (via @mateusrevoredo)
 - Add support for Smooth Mouse (via @mateusrevoredo)
+- Add support for MacDown (via @mateusrevoredo)
 - Fixed Gear Player Support (via @TCattd)
 - Fixed Mailplane Support (via @TCattd)
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [LittleSnitch](http://www.obdev.at/products/littlesnitch/)
 - [Livestreamer](http://livestreamer.tanuki.se/)
 - [MacDive](http://www.mac-dive.com/)
+- [MacDown](http://macdown.uranusjr.com/)
 - [MacOSX](http://www.apple.com/osx/)
 - [MacVim](https://code.google.com/p/macvim/)
 - [Magic Launch](https://www.oneperiodic.com/products/magiclaunch/)

--- a/mackup/applications/macdown.cfg
+++ b/mackup/applications/macdown.cfg
@@ -1,0 +1,6 @@
+[application]
+name = MacDown
+
+[configuration_files]
+Library/Preferences/com.uranusjr.macdown.plist
+Library/Application Support/MacDown


### PR DESCRIPTION
"Library/Application Support/MacDown" folder only contains Styles and Themes files.