### PR TITLE
Alpha sort backup, restore, uninstall

### DIFF
--- a/mackup/main.py
+++ b/mackup/main.py
@@ -81,7 +81,7 @@ def main():
         mckp.check_for_usable_backup_env()
 
         # Backup each application
-        for app_name in mckp.get_apps_to_backup():
+        for app_name in sorted(mckp.get_apps_to_backup()):
             app = ApplicationProfile(mckp,
                                      app_db.get_files(app_name),
                                      dry_run,
@@ -112,7 +112,7 @@ def main():
         # Mackup has already been done
         app_names.discard(MACKUP_APP_NAME)
 
-        for app_name in app_names:
+        for app_name in sorted(app_names):
             app = ApplicationProfile(mckp,
                                      app_db.get_files(app_name),
                                      dry_run,
@@ -136,7 +136,7 @@ def main():
             app_names = mckp.get_apps_to_backup()
             app_names.discard(MACKUP_APP_NAME)
 
-            for app_name in app_names:
+            for app_name in sorted(app_names):
                 app = ApplicationProfile(mckp,
                                          app_db.get_files(app_name),
                                          dry_run,


### PR DESCRIPTION
Starting to play around with mackup again and was testing the verbose and dry run options. I noticed that the output when running the main commands is in a somewhat arbitrary order (didn't track down exactly why, didn't seem to be because os.listdir is arbitrary but maybe just because it's a set), I think mackup's main commands should be sorted like `list` is.