### PR TITLE
Fix for neovim config path change.

### DIFF
--- a/mackup/applications/neovim.cfg
+++ b/mackup/applications/neovim.cfg
@@ -2,5 +2,4 @@
 name = neovim
 
 [configuration_files]
-.nvimrc
-.nvim
+.config/nvim


### PR DESCRIPTION
Neovim now changes to XDG configuration path.