### PR TITLE
Remove support for iTerm2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add support for Ansible (via @mlrobinson)
 - Add support for Querious (via @ryanjbonnell)
 - Add support for IntelliJ IDEA 15 (via @singles)
+- Removed iTerm2 support since iTerm2 overwrites the symlink (via @adamlogic)
 
 ## Mackup 0.8.12
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [i3](https://i3wm.org/)
 - [iStat Menus 5](https://bjango.com/mac/istatmenus/)
 - [IPython](http://ipython.org/)
-- [ITerm2](http://www.iterm2.com/)
 - [JSHint](http://jshint.com/)
 - [Janus](https://github.com/carlhuda/janus)
 - [jrnl](http://maebert.github.io/jrnl/)

--- a/mackup/applications/iterm2.cfg
+++ b/mackup/applications/iterm2.cfg
@@ -1,5 +1,0 @@
-[application]
-name = iTerm2
-
-[configuration_files]
-Library/Preferences/com.googlecode.iterm2.plist


### PR DESCRIPTION
iTerm2 is overwriting the symlink, and it has its own syncing mechanism for preferences.

Fixes #382.