### PR TITLE
Add support for new neovim config path

### DIFF
--- a/mackup/applications/neovim.cfg
+++ b/mackup/applications/neovim.cfg
@@ -2,5 +2,6 @@
 name = neovim
 
 [configuration_files]
+.config/nvim
 .nvimrc
 .nvim


### PR DESCRIPTION
Mentioned in https://github.com/lra/mackup/pull/703 , can close it once merged

Why not both, sync both new and old neovim config path