### PR TITLE
changed wording in readme - mackup uninstall does NOT nuke Mackup folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ You can revert all your files to their original state.
 mackup uninstall
 ```
 
-This will move back any file from Dropbox to its original place in your home
-folder and destroy the Mackup folder in Dropbox.
+This will remove the symlinks and copy back the files from the Mackup folder in Dropbox to their original places in your home. The Mackup folder and the files in it stay put, so that any other computer also running Mackup is unaffected.
 
 ## Supported Storages
 


### PR DESCRIPTION
this one line in the readme has scared me and probably tons of other (and potential) users for ages, seems readme was updated in one spot to reflect the actual behavior but this line wasn't