### PR TITLE
[.oh-my-zsh] Only sync selected files

### DIFF
--- a/mackup/applications/oh-my-zsh.cfg
+++ b/mackup/applications/oh-my-zsh.cfg
@@ -2,4 +2,8 @@
 name = Oh My Zsh
 
 [configuration_files]
-.oh-my-zsh
+.oh-my-zsh/locals.zsh
+.oh-my-zsh/log/.zsh_history
+.oh-my-zsh/projects.zsh
+.oh-my-zsh/custom
+.oh-my-zsh/*.swp


### PR DESCRIPTION
Mackup currently syncs the entire .oh-my-zsh folder. This contains a git repository, cache, and other "system files". The only configuration files which should be synced are those defined in the .gitignore: https://github.com/robbyrussell/oh-my-zsh/blob/master/.gitignore

List of files/folders currently backed up:
 - .git
 - .gitignore
 - MIT-LICENSE.txt
 - README.markdown
 - cache
 - custom
 - lib
 - log
 - oh-my-zsh.sh
 - plugins
 - templates
 - themes
 - tools

**Size**
The current size of the backed up .oh-my-zsh folder is 9mb. Most of this is the git folder (6.3mb) and the plugins folder (2mb). Neither will be backed up with this change.

@lra 