### PR TITLE
Skype fix issue 705

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add support for Rime (via @codefalling)
 - Improved support for R (via @wyf88)
 - Add support for Rhythmbox (via @orschiro)
+- Fixed Skype Support (via @TCattd)
 
 ## Mackup 0.8.12
 

--- a/mackup/applications/skype.cfg
+++ b/mackup/applications/skype.cfg
@@ -2,4 +2,6 @@
 name = Skype
 
 [configuration_files]
-Library/Application Support/Skype
+Library/Application Support/Skype/DataRv
+Library/Application Support/Skype/shared_dynco
+Library/Application Support/Skype/shared_httpfe


### PR DESCRIPTION
Fixes https://github.com/lra/mackup/issues/705

Since we can't blacklist a folder, and can't guess a user's folder (based on Skype user name), we backup just the content outside the user folder to avoid hundreds media files (like emoticons) pushed to Dropbox.
Not the best solution, but to avoid high CPU usage when using Skype, this is needed.

Tested.

My CPU usage wen't crazy because of this, in the middle of a meeting. Dropbox and Skype went berserker for those files. Could not use my laptop until i killed Skype and left Dropbox stop synchronizing all the assorted media Skype stores in there (username named folder). 