### PR TITLE
Use unbroken mdl version (fix build)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   pre:
-    - gem install mdl
+    - gem install mdl -v0.2.1
 
 test:
   override:


### PR DESCRIPTION
The build fails on circleci with:

    mdl 'CHANGELOG.md' 'README.md' 'doc/README.md' 'CONTRIBUTING.md' 'INSTALL.md' 'tests/README.md' 'doc/release.md' 'tests/fixtures/Library/Mobile Documents/com~apple~CloudDocs/_blank_.md'
    /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/mdl-0.3.0/lib/mdl/cli.rb:155:in `probe_config_file': uninitialized constant MarkdownLint::CLI::Pathname (NameError)
    	from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/mdl-0.3.0/lib/mdl/cli.rb:98:in `run'
    	from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/mdl-0.3.0/lib/mdl.rb:14:in `run'
    	from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/mdl-0.3.0/bin/mdl:10:in `<top (required)>'
    	from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/bin/mdl:22:in `load'

    from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/bin/mdl:22:in `<main>' mdl returned exit code 1

It seems to come from a regression in v0.3.0, see https://github.com/mivok/markdownlint/pull/125