### PR TITLE
Adding HyperDock support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added support for Drush (@penance316)
 - Added support for MPS-Youtube (via @fmartingr)
 - Add support for HandBrake (via @ryanjbonnell)
+- Add support for HyperDock (via @leek)
 
 ## Mackup 0.8.13
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Hexels](http://hexraystudios.com/hexels/)
 - [Houdini](http://uglyapps.co.uk/houdini/)
 - [Htop](http://htop.sourceforge.net/)
+- [HyperDock](https://bahoom.com/hyperdock)
 - [HyperSwitch](https://bahoom.com/hyperswitch)
 - [i2cssh](https://github.com/wouterdebie/i2cssh)
 - [i3](https://i3wm.org/)

--- a/mackup/applications/hyperdock.cfg
+++ b/mackup/applications/hyperdock.cfg
@@ -1,0 +1,7 @@
+[application]
+name = HyperDock
+
+[configuration_files]
+Library/Application Support/HyperDock
+Library/Preferences/de.bahoom.HyperDock.plist
+Library/Preferences/de.bahoom.HyperDock.prefpane.plist


### PR DESCRIPTION
Simply adding support for [HyperDock](https://bahoom.com/hyperdock/).