### PR TITLE
Handle multiple dropboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add support for liquidprompt (via @GochoMugo)
 - Add support for REdshift (via @orschiro)
 - Add support for ShowyEdge (via @zanderzhng)
+- Add support for multiple linked Dropbox folders on initial config (via @jbz)
 
 ## Mackup 0.8.11
 

--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -225,7 +225,7 @@ def get_dropbox_folder_location():
         else:
             print "Multiple Dropbox accounts found!"
             for account in accounts:
-                print account 
+                print account
             select = raw_input('Which account would you like to use? ')
             if select not in accounts:
                 error("That's not a valid account.")


### PR DESCRIPTION
If the user has a Personal *and* Business Dropbox, only one will be in hosts.db and it's not deterministic which.  This PR mods utils.py to check info.json (the new account file) on create config - if there are more that one accounts listed, it notifies the user and asks them to pick one to get the mackup folder path from.  If there is one account in info.json, it behaves as before; if info.json isn't available, it tries hosts.db as a fallback, and if neither, then errors.

Did this because syncing to a Dropbox once means making your files visible in version control on that organization (recover deleted) even if you'd prefer not to. Also means not having to go try to move the mackup folder once configured.

## Possible Issues ##

I've seen issues with info.json not being updated by Dropbox when an account is unlinked, or re-linked.  However, the code will still act sensibly given the information in it.  I have a bug filed with Dropbox about info.json not updating.