### PR TITLE
Viscosity only needs the OpenVPN folder + plist

### DIFF
--- a/mackup/applications/viscosity.cfg
+++ b/mackup/applications/viscosity.cfg
@@ -2,5 +2,5 @@
 name = Viscosity
 
 [configuration_files]
-Library/Application Support/Viscosity
+Library/Application Support/Viscosity/OpenVPN
 Library/Preferences/com.viscosityvpn.Viscosity.plist


### PR DESCRIPTION
Including the whole Application support folder includes the .Sparkle folder which seems to get very large over time with viscosity in particular as its not clearing out old versions like other apps seem to do

thankfully Viscosity only seems to create one folder in here so if we capture that then everything still fine

effectively fixes #364
