### PR TITLE
Added additional Navicat products to Navicat support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Added additional Navicat products to existing support (via @drbyte)
+
 ## Mackup 0.8.14
 
 - Add support for PhpStorm 2016.1 (via @driesvints)

--- a/mackup/applications/navicat.cfg
+++ b/mackup/applications/navicat.cfg
@@ -3,4 +3,8 @@ name = Navicat
 
 [configuration_files]
 Library/Application Support/PremiumSoft CyberTech
+Library/Application Support/Navicat for MySQL
+Library/Application Support/Navicat Premium
+Library/Preferences/com.prect.Navicat.plist
+Library/Preferences/com.prect.NavicatPremium.plist
 Library/Preferences/com.prect.NavicatPremiumEssentials.plist


### PR DESCRIPTION
Previously only supported `Navicat Premium Essentials` (which I believe is a Mac App Store app), but not the vendor-supplied versions of `Navicat for MySQL` and  `Navicat Premium`

(There are still more variants, but I don't own them to be able to test them, so not including those here.)
