### PR TITLE
Add Visual Studio Code - Insiders support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add support for Ctags (via @joshmedeski)
 - Add support for KeepingYouAwake (via @zharmany)
 - Add support for Terminal (via @ryanjbonnell)
+- Add support for Visual Studio Code - Insiders (via @dannyamey)
 
 ## Mackup 0.8.14
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Vimperator](http://www.vimperator.org/vimperator)
 - [Viscosity](http://www.sparklabs.com/viscosity/)
 - [Visual Studio Code](https://code.visualstudio.com)
+- [Visual Studio Code - Insiders](https://code.visualstudio.com)
 - [VLC](http://www.videolan.org/)
 - [Wakatime](https://wakatime.com/)
 - [WebStorm](https://www.jetbrains.com/webstorm/)

--- a/mackup/applications/vscode-insiders.cfg
+++ b/mackup/applications/vscode-insiders.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Visual Studio Code - Insiders
+
+[configuration_files]
+Library/Application Support/Code - Insiders/User


### PR DESCRIPTION
Add support for the [Insiders build](https://code.visualstudio.com/blogs/2016/02/01/introducing_insiders_build) of Visual Studio Code.
