### PR TITLE
Changed the pip command to install system wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ If not running OS X, or you don't like Homebrew, you can use [pip](https://pip.p
 > is already installed on your system.
 > If this is the case, it will be upgraded to the latest version.
 
+> On **Ubuntu**, pip will install to the current user's home
+> directory rather than system-wide. Because of this, when
+> installing pip on **Ubuntu** you will need to run `pip install`
+> with the `--system` flag as well (on other platforms this is not
+> needed)
+
 ```bash
 # Install Mackup with PIP
 pip install --upgrade mackup


### PR DESCRIPTION
The mac install instructions suggest using homebrew, which installs
mackup system wide in /usr/local. For other operating systems it
suggests pip, but by default pip installs to the user's home
directory. That's great, but it's not automatically in the $PATH (like
/usr/local/bin is) and this can be confusing for users who aren't used
to python.

I've changed the install instructions to recommend installing system
wide, because of this.
