### PR TITLE
Add support for Ctags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add support for Kwm (via @neon64)
 - Add support for Surge (via @Altynai)
 - Add support for HyperTerm (via @atipugin)
+- Add support for Ctags (via @joshmedeski)
 
 ## Mackup 0.8.14
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [CopyQ](https://github.com/hluk/CopyQ)
 - [CoRD](http://cord.sourceforge.net/)
 - [CotEditor](http://coteditor.com/)
+- [Ctags](http://ctags.sourceforge.net/)
 - [Cyberduck](https://cyberduck.io/)
 - [Dash](https://kapeli.com/dash)
 - [Day-O](http://www.shauninman.com/archive/2011/10/20/day_o_mac_menu_bar_clock)

--- a/mackup/applications/ctags.cfg
+++ b/mackup/applications/ctags.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Ctags
+
+[configuration_files]
+.ctags


### PR DESCRIPTION
Added another commonly used config file for developers: Exuberant Ctags

This file is just a configuration file for default `ctag` commands.

Fixes #509