### PR TITLE
Updating support for FileZilla

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Fantastical](http://flexibits.com/fantastical)
 - [fasd](https://github.com/clvv/fasd)
 - [Feeds](http://www.feedsapp.com/)
-- [Filezilla](https://filezilla-project.org/)
+- [FileZilla](https://filezilla-project.org/)
 - [Fish](http://ridiculousfish.com/shell/)
 - [Flux](https://justgetflux.com/)
 - [FontExplorer X](http://www.fontexplorerx.com/)

--- a/mackup/applications/filezilla.cfg
+++ b/mackup/applications/filezilla.cfg
@@ -1,5 +1,8 @@
 [application]
-name = Filezilla
+name = FileZilla
 
 [configuration_files]
+.config/filezilla/filezilla.xml
+.config/filezilla/layout.xml
+.config/filezilla/sitemanager.xml
 .filezilla


### PR DESCRIPTION
I chose not to just include `.config/filezilla` because it also contains cache, lockfile(s), and a SQLite database of currently uploading files/queue.

If this PR is accepted - then you can close #817.
