### PR TITLE
allow an 'abspath' config setting to set an absolute storage path

### DIFF
--- a/mackup/config.py
+++ b/mackup/config.py
@@ -218,6 +218,10 @@ class Config(object):
                 raise ConfigError("The required 'path' can't be found while"
                                   " the 'file_system' engine is used.")
 
+        # allow an absolute path override
+        if self._parser.has_option('storage', 'abspath'):
+            path = self._parser.get('storage', 'abspath')
+
         # Python 2 and python 3 byte strings are different.
         if sys.version_info[0] < 3:
             path = str(path)


### PR DESCRIPTION
When using Dropbox, the `path` is constructed for the user. If, however, the user has placed the Dropbox folder in another location, the path won't match what Mackup assumes. This `abspath` config option in the `storage` section allows an absolute path to be provided for the base directory for Mackup.