### PR TITLE
Updating Oh My Zsh config to be more specific

### DIFF
--- a/mackup/applications/oh-my-zsh.cfg
+++ b/mackup/applications/oh-my-zsh.cfg
@@ -2,4 +2,4 @@
 name = Oh My Zsh
 
 [configuration_files]
-.oh-my-zsh
+.oh-my-zsh/custom


### PR DESCRIPTION
Syncing the whole `.oh-my-zsh` directory is unnecessary and was breaking for me. User's custom scripts/config should be located in the `custom` directory only - so let's just sync that.