### PR TITLE
fix(config.py): replace 'str(path)' with 'path.encode(utf-8)'

### DIFF
--- a/mackup/config.py
+++ b/mackup/config.py
@@ -220,7 +220,7 @@ class Config(object):
 
         # Python 2 and python 3 byte strings are different.
         if sys.version_info[0] < 3:
-            path = str(path)
+            path = path.encode("utf-8")
         else:
             path = path.decode("utf-8")
 


### PR DESCRIPTION
I got UnicodeEncodeError when do backup with engine `google_drive`.
eg. `str(u"Google 云端硬盘")` 

Signed-off-by: weiyang weiyang.ones@gmail.com
