### PR TITLE
Fix unexpected exception when the home file is a broken link file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add support for FlexGet (via @benwa)
 - Add support for Ctags (via @joshmedeski)
 - Add support for KeepingYouAwake (via @zharmany)
+- Don't fail when the home file is a broken link. (via @zhangfandong)
 
 ## Mackup 0.8.14
 

--- a/mackup/application.py
+++ b/mackup/application.py
@@ -152,7 +152,9 @@ class ApplicationProfile(object):
             # any subfolder of ~/Library on GNU/Linux)
             file_or_dir_exists = (os.path.isfile(mackup_filepath) or
                                   os.path.isdir(mackup_filepath))
-            pointing_to_mackup = (os.path.islink(home_filepath) and
+            is_valid_link = (os.path.islink(home_filepath) and
+                             os.path.exists(home_filepath))
+            pointing_to_mackup = (is_valid_link and
                                   os.path.exists(mackup_filepath) and
                                   os.path.samefile(mackup_filepath,
                                                    home_filepath))
@@ -190,14 +192,14 @@ class ApplicationProfile(object):
                 else:
                     utils.link(mackup_filepath, home_filepath)
             elif self.verbose:
-                if os.path.exists(home_filepath):
+                if pointing_to_mackup:
                     print("Doing nothing\n  {}\n  already linked by\n  {}"
                           .format(mackup_filepath, home_filepath))
-                elif os.path.islink(home_filepath):
+                elif not is_valid_link:
                     print("Doing nothing\n  {}\n  "
                           "is a broken link, you might want to fix it."
                           .format(home_filepath))
-                else:
+                else:  # not file_or_dir_exists
                     print("Doing nothing\n  {}\n  does not exist"
                           .format(mackup_filepath))
 


### PR DESCRIPTION
When the home file is an broken symbolic link, `os.path.samefile` will fail. This can happen when user move backup folder to other places, resulting all the symbolic files broken.