### PR TITLE
Fix unexpected exception when the home file is a broken link and add related test cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add support for FlexGet (via @benwa)
 - Add support for Ctags (via @joshmedeski)
 - Add support for KeepingYouAwake (via @zharmany)
+- Don't fail when the home file is a broken link. (via @zhangfandong)
 
 ## Mackup 0.8.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add support for Ctags (via @joshmedeski)
 - Add support for KeepingYouAwake (via @zharmany)
 - Don't fail when the home file is a broken link. (via @zhangfandong)
+- Add tests to cover application restore. (via @zhangfandong)
 
 ## Mackup 0.8.14
 

--- a/mackup/application.py
+++ b/mackup/application.py
@@ -152,7 +152,9 @@ class ApplicationProfile(object):
             # any subfolder of ~/Library on GNU/Linux)
             file_or_dir_exists = (os.path.isfile(mackup_filepath) or
                                   os.path.isdir(mackup_filepath))
-            pointing_to_mackup = (os.path.islink(home_filepath) and
+            is_valid_link = (os.path.islink(home_filepath) and
+                             os.path.exists(home_filepath))
+            pointing_to_mackup = (is_valid_link and
                                   os.path.exists(mackup_filepath) and
                                   os.path.samefile(mackup_filepath,
                                                    home_filepath))
@@ -169,7 +171,7 @@ class ApplicationProfile(object):
                     continue
 
                 # Check if there is already a file in the home folder
-                if os.path.exists(home_filepath):
+                if os.path.lexists(home_filepath):
                     # Name it right
                     if os.path.isfile(home_filepath):
                         file_type = 'file'
@@ -190,14 +192,14 @@ class ApplicationProfile(object):
                 else:
                     utils.link(mackup_filepath, home_filepath)
             elif self.verbose:
-                if os.path.exists(home_filepath):
+                if pointing_to_mackup:
                     print("Doing nothing\n  {}\n  already linked by\n  {}"
                           .format(mackup_filepath, home_filepath))
-                elif os.path.islink(home_filepath):
+                elif not is_valid_link:
                     print("Doing nothing\n  {}\n  "
                           "is a broken link, you might want to fix it."
                           .format(home_filepath))
-                else:
+                else:  # not file_or_dir_exists
                     print("Doing nothing\n  {}\n  does not exist"
                           .format(mackup_filepath))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 nose
 flake8
 codecov
+mock

--- a/tests/application_tests.py
+++ b/tests/application_tests.py
@@ -1,0 +1,133 @@
+from mackup import application, mackup
+
+import mock
+import unittest
+import os
+import shutil
+import tempfile
+import contextlib
+
+
+class TestApplicationProfile(unittest.TestCase):
+
+    def setUp(self):
+        self.fake_home = tempfile.mkdtemp()
+        self.fake_mackup = os.path.join(self.fake_home, 'mackup')
+
+        # Fake home path.
+        os.environ['HOME'] = self.fake_home
+
+        # mackup/home file path for testing
+        filename = 'test.rc'
+        self.home_filepath = self.prepend_home_path(filename)
+        self.mackup_filepath = self.prepend_mackup_path(filename)
+
+        # Mock mackup
+        mckp = mock.MagicMock(spec=mackup.Mackup)
+        mckp.mackup_folder = self.fake_mackup
+
+        self.app = application.ApplicationProfile(mckp, {filename},
+                                                  dry_run=False,
+                                                  verbose=False)
+
+    def tearDown(self):
+        shutil.rmtree(self.fake_home)
+
+    @staticmethod
+    def create_file(filename):
+        dirname = os.path.dirname(filename)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+        with open(filename, 'w') as f:
+            f.write('this is a test file')
+
+    @staticmethod
+    @contextlib.contextmanager
+    def confirm(answer):
+        with mock.patch('mackup.utils.confirm') as confirm:
+            confirm.return_value = answer
+            yield
+
+    def prepend_home_path(self, filename):
+        return os.path.join(self.fake_home, filename)
+
+    def prepend_mackup_path(self, filename):
+        return os.path.join(self.fake_mackup, filename)
+
+    def test_restore_without_home_file(self):
+        self.create_file(self.mackup_filepath)
+        self.app.restore()
+
+        self.assertTrue(os.path.islink(self.home_filepath))
+        self.assertTrue(os.path.exists(self.home_filepath))
+        self.assertTrue(os.path.samefile(self.home_filepath, self.mackup_filepath))
+
+    def test_restore_with_pointing_to_mackup(self):
+        self.create_file(self.mackup_filepath)
+        os.symlink(self.mackup_filepath, self.home_filepath)
+
+        with self.confirm(True):
+            self.app.restore()
+
+        self.assertTrue(os.path.exists(self.home_filepath))
+        self.assertTrue(os.path.exists(self.mackup_filepath))
+        self.assertTrue(os.path.samefile(self.home_filepath, self.mackup_filepath))
+
+    def test_restore_broken_link(self):
+        self.create_file(self.mackup_filepath)
+        os.symlink('broken_link', self.home_filepath)
+
+        # home_filepath should be a broken link
+        assert(os.path.islink(self.home_filepath) and
+               not os.path.exists(self.home_filepath))
+
+        with self.confirm(False):
+            self.app.restore()
+
+        self.assertTrue(os.path.islink(self.home_filepath) and
+                        not os.path.exists(self.home_filepath))
+
+        with self.confirm(True):
+            self.app.restore()
+
+        self.assertTrue(os.path.islink(self.home_filepath) and
+                        os.path.exists(self.home_filepath))
+        self.assertTrue(os.path.samefile(self.home_filepath, self.mackup_filepath))
+
+    def test_restore_pointing_to_other(self):
+        other_filepath = self.prepend_home_path('other_file')
+        self.create_file(self.mackup_filepath)
+        self.create_file(other_filepath)
+        os.symlink(other_filepath, self.home_filepath)
+
+        assert(not os.path.samefile(other_filepath, self.mackup_filepath))
+        assert(os.path.samefile(other_filepath, self.home_filepath))
+
+        with self.confirm(False):
+            self.app.restore()
+
+        self.assertFalse(os.path.samefile(other_filepath, self.mackup_filepath))
+        self.assertTrue(os.path.samefile(other_filepath, self.home_filepath))
+
+        with self.confirm(True):
+            self.app.restore()
+
+        self.assertFalse(os.path.samefile(self.home_filepath, other_filepath))
+        self.assertTrue(os.path.samefile(self.mackup_filepath, self.home_filepath))
+
+    def test_restore_other_file(self):
+        self.create_file(self.home_filepath)
+        self.create_file(self.mackup_filepath)
+
+        assert(not os.path.samefile(self.home_filepath, self.mackup_filepath))
+
+        with self.confirm(False):
+            self.app.restore()
+
+        self.assertFalse(os.path.samefile(self.home_filepath, self.mackup_filepath))
+
+        with self.confirm(True):
+            self.app.restore()
+
+        self.assertTrue(os.path.samefile(self.home_filepath, self.mackup_filepath))
+        self.assertTrue(os.path.islink(self.home_filepath))


### PR DESCRIPTION
When `home_filepath` is a broken link, the `os.path.samefile` will raise exception `OSError: [Errno 2] No such file or directory`.The patchs fix this problem and also add related test cases.

It should also fix issues #784 and #559.
