### PR TITLE
Add Factorio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add support for Ctags (via @joshmedeski)
 - Add support for KeepingYouAwake (via @zharmany)
 - Add support for Terminal (via @ryanjbonnell)
+- Add support for Factorio (via @icopp)
 
 ## Mackup 0.8.14
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Enjoyable](https://yukkurigames.com/enjoyable/)
 - [Exercism](http://exercism.io/)
 - [ExpanDrive](http://www.expandrive.com/)
+- [Factorio](https://www.factorio.com)
 - [Fantastical](http://flexibits.com/fantastical)
 - [fasd](https://github.com/clvv/fasd)
 - [Feeds](http://www.feedsapp.com/)

--- a/mackup/applications/factorio.cfg
+++ b/mackup/applications/factorio.cfg
@@ -1,0 +1,8 @@
+[application]
+name = Factorio
+
+[configuration_files]
+Library/Application Support/factorio/config
+Library/Application Support/factorio/mods
+Library/Application Support/factorio/saves
+Library/Application Support/factorio/player-data.json


### PR DESCRIPTION
Adds the configuration files/folders for the game [Factorio](https://www.factorio.com).

This doesn't add the base `Library/Application Support/factorio` folder because the game keeps a large compiled assets cache file there (500+ MB).
