### PR TITLE
Add Ancient Domains of Mystery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add support for Ctags (via @joshmedeski)
 - Add support for KeepingYouAwake (via @zharmany)
 - Add support for Terminal (via @ryanjbonnell)
+- Add support for Ancient Domains of Mystery (via @icopp)
 
 ## Mackup 0.8.14
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Adium](https://adium.im/)
 - [Adobe Camera Raw](http://www.adobe.com/products/photoshop/extend.html)
 - [Adobe Photoshop CC](http://www.adobe.com/products/photoshop.html)
+- [Ancient Domains of Mystery](http://www.adom.de/home/index.html)
 - [Android Studio](https://developer.android.com/sdk/)
 - [Ansible](http://www.ansible.com/)
 - [AppCleaner](http://freemacsoft.net/appcleaner/)

--- a/mackup/applications/ancient-domains-of-mystery.cfg
+++ b/mackup/applications/ancient-domains-of-mystery.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Ancient Domains of Mystery
+
+[configuration_files]
+.adom.data


### PR DESCRIPTION
Adds the configuration folder for the game [Ancient Domains of Mystery](http://www.adom.de/home/index.html).
