### PR TITLE
Remove trailing slash from kwm.cfg

### DIFF
--- a/mackup/applications/kwm.cfg
+++ b/mackup/applications/kwm.cfg
@@ -2,4 +2,4 @@
 name = Kwm
 
 [configuration_files]
-.kwm/
+.kwm


### PR DESCRIPTION
This commit is to fix the following error generated from a trailing slash in `kwm.cfg`:
```bash
Traceback (most recent call last):
  File "/usr/local/Cellar/mackup/0.8.14/libexec/bin/mackup", line 9, in <module>
    load_entry_point('mackup==0.8.14', 'console_scripts', 'mackup')()
  File "/usr/local/Cellar/mackup/0.8.14/libexec/lib/python2.7/site-packages/mackup/main.py", line 86, in main
    app_db.get_files(app_name),
  File "/usr/local/Cellar/mackup/0.8.14/libexec/lib/python2.7/site-packages/mackup/appsdb.py", line 145, in get_files
    return self.apps[name]['configuration_files']
KeyError: 'kwm'
```