### PR TITLE
Rename HyperTerm to Hyper

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Htop](http://htop.sourceforge.net/)
 - [HyperDock](https://bahoom.com/hyperdock)
 - [HyperSwitch](https://bahoom.com/hyperswitch)
-- [HyperTerm](https://hyperterm.org)
+- [Hyper](https://hyper.is)
 - [i2cssh](https://github.com/wouterdebie/i2cssh)
 - [i3](https://i3wm.org/)
 - [i3wm](http://i3wm.org/)

--- a/mackup/applications/hyper.cfg
+++ b/mackup/applications/hyper.cfg
@@ -1,5 +1,5 @@
 [application]
-name = HyperTerm
+name = Hyper
 
 [configuration_files]
-.hyperterm.js
+.hyper.js


### PR DESCRIPTION
Following [official announcement](https://zeit.co/blog/the-hyper-plan), this commit is to rename HyperTerm to Hyper.

I did check the name with the [author](https://twitter.com/rauchg/) as there was a bit of confusion online between *Hyper* and *Hyper.app*, however he confirmed *Hyper* as the official one.