### PR TITLE
Improve Visual Studio Code synchronization

### DIFF
--- a/mackup/applications/vscode.cfg
+++ b/mackup/applications/vscode.cfg
@@ -2,10 +2,11 @@
 name = Visual Studio Code
 
 [configuration_files]
-Library/Application Support/Code/User
+Library/Application Support/Code/User/snippets
+Library/Application Support/Code/User/keybindings.json
+Library/Application Support/Code/User/settings.json
 
 # Linux Files
-.vscode
 .config/Code/User/snippets
 .config/Code/User/keybindings.json
 .config/Code/User/settings.json


### PR DESCRIPTION
- Do not sync .vscode folder on Linux, since it contains all Node dependencies
- Explicitly sync files on macOS to prevent syncing workspaceStorage folder

As I have mentioned [in the related commit](https://github.com/lra/mackup/commit/a58b767022c05a4add0150f926c0fb7d7fa21d0a#commitcomment-20162655), `.vscode` is troublesome to be synced by default. I have also expanded which files need to be synced on macOS, because with the current configuration also `workspaceStorage` is synced, which is usually system-specific.

VSCode currently isn't very Mackup-friendly, but there is [discussion about improvements](https://github.com/Microsoft/vscode/issues/2743) and also there are a few plugins like [CodeSync](https://marketplace.visualstudio.com/items?itemName=golf1052.code-sync) which can sync extensions without all the mess of dependencies.