### PR TITLE
Explicitly list macdown sync to avoid syncing sparkle cache

### DIFF
--- a/mackup/applications/macdown.cfg
+++ b/mackup/applications/macdown.cfg
@@ -3,4 +3,5 @@ name = MacDown
 
 [configuration_files]
 Library/Preferences/com.uranusjr.macdown.plist
-Library/Application Support/MacDown
+Library/Application Support/MacDown/Styles
+Library/Application Support/MacDown/Themes


### PR DESCRIPTION
Same issue as https://github.com/lra/mackup/issues/364