### PR TITLE
don't try to chmod temporarily orphaned symlinks during restore

### DIFF
--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -175,7 +175,9 @@ def chmod(target):
             for cur_dir in dirs:
                 os.chmod(os.path.join(root, cur_dir), folder_mode)
             for cur_file in files:
-                os.chmod(os.path.join(root, cur_file), file_mode)
+                fullpath = os.path.join(root, cur_file)
+                if os.path.isfile(fullpath):
+                    os.chmod(fullpath, file_mode)
 
     else:
         raise ValueError("Unsupported file type: {}".format(target))

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -250,8 +250,17 @@ class TestMackup(unittest.TestCase):
         file_name = tfile.name
 
         # Create a tmp directory with a sub folder
-        dir_name = tempfile.mkdtemp()
+        dir_name = tempfile.mkdtemp(prefix='mackup-tests-')
         nested_dir = tempfile.mkdtemp(dir=dir_name)
+
+        # Create orphaned link
+        link_target = tempfile.NamedTemporaryFile(dir=nested_dir, delete=False)
+        link_name   = os.path.join(dir_name, 'link')
+        os.symlink(link_target.name, link_name)
+        os.remove(link_target.name)
+        assert not os.path.isfile(link_target.name)
+        assert not os.path.isfile(link_name)
+        assert os.path.islink(link_name)
 
         # # File Tests
 


### PR DESCRIPTION
actual use case (as layed out in [#710](https://github.com/lra/mackup/issues/710#issuecomment-278811040))

let's say you have fish and fisherman backed up with mackup.
fisherman puts links into fish's config directory.

on a new machine you then run mackup restore
and because of the way mackup handles .mackup.cfg entries,
it might try to restore fish with its symlinks first
-- essentially restoring orphaned links -- and then
it restores fisherman and its files, making the symlinks valid again.

this patch modifies chmod tests to reflect the situation and fixes the crash i'm currently experiencing:
```
$ nosetests
..................E..............
======================================================================
ERROR: test_chmod_file (utils_test.TestMackup)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/martin/Code/mackup/tests/utils_test.py", line 289, in test_chmod_file
    utils.chmod(dir_name)
  File "/Users/martin/Code/mackup/mackup/utils.py", line 178, in chmod
    os.chmod(os.path.join(root, cur_file), file_mode)
OSError: [Errno 2] No such file or directory: '/var/folders/r0/xh9rk2794rl1yndl3crn91x00000gn/T/mackup-tests-O9R3iC/link'
-------------------- >> begin captured stdout << ---------------------
--

--------------------- >> end captured stdout << ----------------------

----------------------------------------------------------------------
Ran 33 tests in 0.110s

FAILED (errors=1)
```

after: 
```
$ nosetests
.................................
----------------------------------------------------------------------
Ran 33 tests in 0.197s

OK
```