### PR TITLE
backup pip.conf from all the possible places named on the docs

### DIFF
--- a/mackup/applications/pip.cfg
+++ b/mackup/applications/pip.cfg
@@ -2,4 +2,9 @@
 name = pip
 
 [configuration_files]
+Library/Application Support/pip/pip.conf
 .pip/pip.conf
+
+[xdg_configuration_files]
+pip/pip.conf
+

--- a/mackup/applications/pip.cfg
+++ b/mackup/applications/pip.cfg
@@ -7,4 +7,3 @@ Library/Application Support/pip/pip.conf
 
 [xdg_configuration_files]
 pip/pip.conf
-


### PR DESCRIPTION
the [docs](https://pip.pypa.io/en/stable/user_guide/#config-file) say that the user-specific `pip.conf` may be found in multiple places.

this patch adds
- `.config/pip/pip.conf`
- `Library/Application Support/pip/pip.conf`

in addition to `.pip/pip.conf`.