### PR TITLE
Added support for Things by Cultured Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 
+- Add support for Things (via @zharmany)
 - Add support for Boxer (via @icopp)
 
 ## Mackup 0.8.16

--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [TextExpander](https://smilesoftware.com/textexpander)
 - [TextMate](http://macromates.com/)
 - [Textual](http://www.codeux.com/textual/)
+- [Things](https://culturedcode.com/things/)
 - [Tig](https://github.com/jonas/tig)
 - [tint2](https://code.google.com/p/tint2/)
 - [TinyFugue](http://tinyfugue.sourceforge.net)

--- a/mackup/applications/things.cfg
+++ b/mackup/applications/things.cfg
@@ -1,0 +1,6 @@
+[application]
+name = Things
+
+[configuration_files]
+Library/Preferences/com.culturedcode.things.plist
+Library/Application Support/Cultured Code/Licenses.plist


### PR DESCRIPTION
The configuration file `Library/Preferences/com.culturedcode.things.plist` hosts the application settings. This will also sync the license information in `Library/Application Support/Cultured Code/Licenses.plist`. I'm unsure if the license information is considered "sensitive information" as stated in `CONTRIBUTING.md`.

Things supports syncing through Cultured Code's "Things Cloud". This login information seems to be stored by macOS Keychain, not through any `.plist` file, and will have to be entered on a per-machine basis.

Again, thanks for all the great work on Mackup! 