### PR TITLE
Corrected readme for #295 no longer syncing private keys by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Gmail Notifr](http://ashchan.com/projects/gmail-notifr)
 - [GMVault](http://gmvault.org/)
 - [Gnome SSH Tunnel Manager](http://sourceforge.net/projects/gstm/)
-- [GnuPG](https://www.gnupg.org/)  (NOTE: includes private keys)
+- [GnuPG](https://www.gnupg.org/)  (NOTE: private keys NOT synced by default)
 - [Go2Shell](http://zipzapmac.com/Go2Shell)
 - [Gogland](https://www.jetbrains.com/go/)
 - [GoShare](https://github.com/dictget/goshare)
@@ -371,7 +371,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [OmniFocus](https://www.omnigroup.com/omnifocus/)
 - [OmniGraffle](https://www.omnigroup.com/omnigraffle/)
 - [OpenEmu](http://openemu.org)
-- [OpenSSH](http://www.openssh.com/) (NOTE: includes private keys)
+- [OpenSSH](http://www.openssh.com/) (NOTE: private keys NOT synced by default)
 - [Paintbrush](http://paintbrush.sourceforge.net/)
 - [Pandoc](http://pandoc.org)
 - [Pass](http://www.passwordstore.org/)
@@ -510,6 +510,19 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [z](https://github.com/rupa/z)
 - [zathura](https://pwmt.org/projects/zathura/)
 - [Zsh](http://zsh.sourceforge.net/)
+
+## Syncing private keys
+
+By default private keys for OpenSSH and GnuPG are NOT sycned. You can sync your private keys if you
+want. For example, to sync your entire OpenSSH `.ssh` directory, create a `~/.mackup/ssh.cfg` file
+with the following content:
+```
+[application]
+name = SSH
+
+[configuration_files]
+.ssh
+```
 
 ## Can you support application X
 


### PR DESCRIPTION
I was confused why my .ssh folder wasn't syncing as I wanted until I found issue #295. This helps provide correct info for people reading the readme.

This is related to #976 which updates to help message.