### PR TITLE
Update support for PyCharm and add PyCharmCE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Add support for Boxer (via @icopp)
+- Update support for Pycharm (via @scooby)
 
 ## Mackup 0.8.16
 

--- a/mackup/applications/pycharm.cfg
+++ b/mackup/applications/pycharm.cfg
@@ -10,7 +10,38 @@ Library/Application Support/PyCharm50
 Library/Preferences/PyCharm50
 .PyCharm2016.1/config
 .PyCharm2016.2/config
+.PyCharm2016.3/config
+.PyCharm2017.1/config
+.PyCharm2017.2/config
+.PyCharm2017.3/config
 Library/Application Support/PyCharm2016.1
 Library/Application Support/PyCharm2016.2
+Library/Application Support/PyCharm2016.3
+Library/Application Support/PyCharm2017.1
+Library/Application Support/PyCharm2017.2
+Library/Application Support/PyCharm2017.3
 Library/Preferences/PyCharm2016.1
 Library/Preferences/PyCharm2016.2
+Library/Preferences/PyCharm2016.3
+Library/Preferences/PyCharm2017.1
+Library/Preferences/PyCharm2017.2
+Library/Preferences/PyCharm2017.3
+
+.PyCharmCE2016.1/config
+.PyCharmCE2016.2/config
+.PyCharmCE2016.3/config
+.PyCharmCE2017.1/config
+.PyCharmCE2017.2/config
+.PyCharmCE2017.3/config
+Library/Application Support/PyCharmCE2016.1
+Library/Application Support/PyCharmCE2016.2
+Library/Application Support/PyCharmCE2016.3
+Library/Application Support/PyCharmCE2017.1
+Library/Application Support/PyCharmCE2017.2
+Library/Application Support/PyCharmCE2017.3
+Library/Preferences/PyCharmCE2016.1
+Library/Preferences/PyCharmCE2016.2
+Library/Preferences/PyCharmCE2016.3
+Library/Preferences/PyCharmCE2017.1
+Library/Preferences/PyCharmCE2017.2
+Library/Preferences/PyCharmCE2017.3


### PR DESCRIPTION
I'm guessing that Jetbrains will release 2017.2 and 2017.3, so it seems reasonable to simply add those entries now.

There's an open issue to add wildcards, I think that would be inappropriate as it could lead to some pretty horrific breakage and it's not much of a lift to update this every year or so.

Let me know if this doesn't work for you, I can restrict it to only adding 2017.1.