### PR TITLE
Remove note about OpenSSH private keys from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Only sync init.vim for neovim (via @foray1010)
 - Support for RubyMine 2018.01 (via @kibitan)
 - Support for IntelliJ Idea 2017.1, 2017.2, 2017.3, and 2018.1 (via @cool00geek)
+- Remove references to OpenSSH private key syncing(removed in dcb26ba)
 
 ## Mackup 0.8.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Only sync init.vim for neovim (via @foray1010)
 - Support for RubyMine 2018.01 (via @kibitan)
 - Support for IntelliJ Idea 2017.1, 2017.2, 2017.3, and 2018.1 (via @cool00geek)
-- Remove references to OpenSSH private key syncing(removed in dcb26ba)
+- Remove references to OpenSSH private key syncing - removed in dcb26ba (via @njdancer)
 
 ## Mackup 0.8.18
 

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [OmniGraffle](https://www.omnigroup.com/omnigraffle/)
 - [Openbox](http://openbox.org)
 - [OpenEmu](http://openemu.org)
-- [OpenSSH](http://www.openssh.com/) (NOTE: includes private keys)
+- [OpenSSH](http://www.openssh.com/)
 - [Paintbrush](http://paintbrush.sourceforge.net/)
 - [Pandoc](http://pandoc.org)
 - [Pass](http://www.passwordstore.org/)

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -22,12 +22,12 @@ Modes of action:
  1. list: display a list of all supported applications.
  2. backup: sync your conf files to your synced storage, use this the 1st time
     you use Mackup. (Note that by default this will sync private keys used by
-    OpenSSH and GnuPG.)
+    and GnuPG.)
  3. restore: link the conf files already in your synced storage on your system,
     use it on any new system you use.
  4. uninstall: reset everything as it was before using Mackup.
 
-By default, Mackup syncs all application data (including private keys!) via
+By default, Mackup syncs all application data (including some private keys!) via
 Dropbox, but may be configured to exclude applications or use a different
 backend with a .mackup.cfg file.
 

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -22,7 +22,7 @@ Modes of action:
  1. list: display a list of all supported applications.
  2. backup: sync your conf files to your synced storage, use this the 1st time
     you use Mackup. (Note that by default this will sync private keys used by
-    and GnuPG.)
+    GnuPG.)
  3. restore: link the conf files already in your synced storage on your system,
     use it on any new system you use.
  4. uninstall: reset everything as it was before using Mackup.

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -27,8 +27,8 @@ Modes of action:
     use it on any new system you use.
  4. uninstall: reset everything as it was before using Mackup.
 
-By default, Mackup syncs all application data (including some private keys!) via
-Dropbox, but may be configured to exclude applications or use a different
+By default, Mackup syncs all application data (including some private keys!)
+via Dropbox, but may be configured to exclude applications or use a different
 backend with a .mackup.cfg file.
 
 See https://github.com/lra/mackup/tree/master/doc for more information.


### PR DESCRIPTION
Private keys were removed from OpenSSH config in dcb26ba.