### PR TITLE
Update BetterTouchTool configuration file paths

### DIFF
--- a/mackup/applications/bettertouchtool.cfg
+++ b/mackup/applications/bettertouchtool.cfg
@@ -3,4 +3,6 @@ name = BetterTouchTool
 
 [configuration_files]
 Library/Preferences/com.hegenberg.BetterTouchTool.plist
-Library/Application Support/BetterTouchTool/bttdata2
+Library/Application Support/BetterTouchTool/btt_data_store.v2
+Library/Application Support/BetterTouchTool/btt_data_store.v2-shm
+Library/Application Support/BetterTouchTool/btt_data_store.v2-wal


### PR DESCRIPTION
This fixed #520 and #1012 for me.

@fifafu 

It looks like [this previous commit](https://github.com/lra/mackup/commit/c2d6e681fef915f35ab03561882d6ed647c16b8c) to the configuration file limited the files and changed it to a directory that no longer exists on recent versions of better touch tool. These files restored my entire configuration from my other computer, however, there *are* other files in that directory locally. Perhaps we should be backing up the entire folder again? 

![screen shot 2017-07-03 at 4 35 52 pm](https://user-images.githubusercontent.com/249164/27810325-b3f157b6-600d-11e7-8a44-28df8aa024fa.png)
