### PR TITLE
Add the correct Exercism config file

### DIFF
--- a/mackup/applications/exercism.cfg
+++ b/mackup/applications/exercism.cfg
@@ -3,3 +3,4 @@ name = Exercism
 
 [configuration_files]
 .exercism
+.exercism.json


### PR DESCRIPTION
It looks like the current implementation copies `.exercism`. However it would appear that the correct file is `.exercism.json`. You can see this in [the Exercism help page](http://exercism.io/help) or if you run `exercism configure`. I've also left in the previous definition as I suspect this perhaps where the config used to be stored.

![image](https://user-images.githubusercontent.com/636753/28328968-1869ef40-6be0-11e7-8639-41cd6c72f2f5.png)

