### PR TITLE
Fasd support updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for Remote Desktop Manager (via @jpmat296)
 - Fixed support for asciinema (via @revolter)
 - Added support for Mumu (via @fharper)
+- Updated support for fasd (via @doubleloop)
 
 ## Mackup 0.8.33
 

--- a/mackup/applications/fasd.cfg
+++ b/mackup/applications/fasd.cfg
@@ -3,3 +3,4 @@ name = fasd
 
 [configuration_files]
 .fasd
+.fasdrc


### PR DESCRIPTION
Added .fasdrc to configuration_files. 
This allows to walk around the issue noticed in
https://github.com/lra/mackup/pull/743#issuecomment-221783525
You can simply set 
```
FASD_DATA="$HOME/.fasd/fasd"
``` 
in .fasdrc and mackup will link the whole directory, so even if fasd deletes/creates data file, it will not break the symlink.