### PR TITLE
Include iCloud in list of storage options. Add numbers to headings.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -22,11 +22,12 @@ directory.
 
 ## Storage
 
-### Dropbox
-
 You can specify the storage type Mackup will use to store your configuration
 files.
-For now you have 4 options: `dropbox`, `google_drive`, `copy` and `file_system`.
+For now you have 5 options: `dropbox`, `google_drive`, `icloud`, `copy` and `file_system`.
+
+### 1. Dropbox
+
 If none is specified, Mackup will try to use the default: `dropbox`.
 With the `dropbox` storage engine, Mackup will automatically figure out your
 Dropbox folder.
@@ -36,7 +37,7 @@ Dropbox folder.
 engine = dropbox
 ```
 
-### Google Drive
+### 2. Google Drive
 
 If you choose the `google_drive` storage engine instead, Mackup will figure out
 where your Google Drive is and store your configuration files in it.
@@ -46,14 +47,14 @@ where your Google Drive is and store your configuration files in it.
 engine = google_drive
 ```
 
-### iCloud
+### 3. iCloud
 
 ```ini
 [storage]
 engine = icloud
 ```
 
-### Copy
+### 4. Copy
 
 If you choose the `copy` storage engine, Mackup will figure out
 where your Copy folder is and store your configuration files in it.
@@ -63,7 +64,7 @@ where your Copy folder is and store your configuration files in it.
 engine = copy
 ```
 
-### File System
+### 5. File System
 
 If you want to specify another directory, you can use the `file_system` engine
 and Mackup won't try to detect any path for you: it will store your files where


### PR DESCRIPTION
Intended to increase clarity. iCloud was explained as an option, but not listed in the initial sentence of the section.