### PR TITLE
Add support for Visual Studio for Mac (#1010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add support for DaisyDisk (via @cafferata)
 - Add support for MySQLWorkbench (via @cafferata)
 - Add support for Openbox (via @jpfarcy)
+- Add support for Visual Studio for Mac (via @ivmirx)
 
 ## Mackup 0.8.16
 

--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Viscosity](http://www.sparklabs.com/viscosity/)
 - [Visual Studio Code - Insiders](https://code.visualstudio.com)
 - [Visual Studio Code](https://code.visualstudio.com)
+- [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/)
 - [VLC](http://www.videolan.org/)
 - [Wakatime](https://wakatime.com/)
 - [WebStorm](https://www.jetbrains.com/webstorm/)

--- a/mackup/applications/vs4mac.cfg
+++ b/mackup/applications/vs4mac.cfg
@@ -1,0 +1,7 @@
+[application]
+name = Visual Studio for Mac
+
+[configuration_files]
+Library/VisualStudio
+Library/Preferences/VisualStudio/7.0/EditingLayout.xml
+Library/Preferences/VisualStudio/7.0/MonoDevelopProperties.xml


### PR DESCRIPTION
Hi, adding VS4Mac. It was previously called Xamarin Studio and got both the name and config paths changed after acquisition by Microsoft.