### PR TITLE
config: Fix typo

### DIFF
--- a/mackup/config.py
+++ b/mackup/config.py
@@ -220,9 +220,9 @@ class Config(object):
 
         # Python 2 and python 3 byte strings are different.
         if sys.version_info[0] < 3:
-            path = str(path)
-        else:
             path = path.decode("utf-8")
+        else:
+            path = str(path)
 
         return path
 


### PR DESCRIPTION
There is no `decode` for str in python 3.