### PR TITLE
feat: only sync init.vim for neovim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support for RubyMine 2017.03 (via @kibitan)
 - Add additional Spectacle library path (via @iansym)
+- Only sync init.vim for neovim (via @foray1010)
 
 ## Mackup 0.8.18
 

--- a/mackup/applications/neovim.cfg
+++ b/mackup/applications/neovim.cfg
@@ -2,6 +2,6 @@
 name = neovim
 
 [configuration_files]
-.config/nvim
+.config/nvim/init.vim
 .nvimrc
 .nvim


### PR DESCRIPTION
the original approach that I did 2 years ago sync the whole `.config/nvim` which is unnecessary since `init.vim` includes all the information like which packages to install and its config
syncing the whole `.config/nvim` will result in uploading all plugins and their `.git` to the cloud which is thousands of files, and very easy to cause file conflicts while syncing