### PR TITLE
Update for IntelliJ Idea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add additional Spectacle library path (via @iansym)
 - Only sync init.vim for neovim (via @foray1010)
 - Support for RubyMine 2018.01 (via @kibitan)
+- Support for IntelliJ Idea 2017.1, 2017.2, 2017.3, and 2018.1 (via @cool00geek)
 
 ## Mackup 0.8.18
 

--- a/mackup/applications/intellijidea.cfg
+++ b/mackup/applications/intellijidea.cfg
@@ -14,11 +14,26 @@ Library/Preferences/IntelliJIdea14
 .IntelliJIdea15/config/
 Library/Application Support/IntelliJIdea15
 Library/Preferences/IntelliJIdea15
+IntelliJIdea2016.1/config/
 Library/Application Support/IntelliJIdea2016.1
 Library/Preferences/IntelliJIdea2016.1
 Library/Application Support/IdeaIC2016.1
 Library/Preferences/IdeaIC2016.1
 Library/Preferences/IntelliJIdea2016.2
 Library/Application Support/IntelliJIdea2016.2
+IntelliJIdea2016.2/config/
 Library/Preferences/IntelliJIdea2016.3
 Library/Application Support/IntelliJIdea2016.3
+IntelliJIdea2016.3/config/
+Library/Preferences/IntelliJIdea2017.1
+Library/Application Support/IntelliJIdea2017.1
+IntelliJIdea2017.1/config/
+Library/Preferences/IntelliJIdea2017.2
+Library/Application Support/IntelliJIdea2017.2
+IntelliJIdea2017.2/config/
+Library/Preferences/IntelliJIdea2017.3
+Library/Application Support/IntelliJIdea2017.3
+IntelliJIdea2017.3/config/
+Library/Preferences/IntelliJIdea2018.1
+Library/Application Support/IntelliJIdea2018.1
+IntelliJIdea2018.1/config/


### PR DESCRIPTION
These updates are for IntellJ Idea, by updating the intellijidea.cfg file.

It now supports the following versions on both macOS and Linux:
- IDEA 2017.1
- IDEA 2017.2
- IDEA 2017.3
- IDEA 2018.1

A previous PR (#1047) does exist, but has not been updated for 2018.1 and has not been merged yet.