### PR TITLE
Allow bootstrapping from iCloud Drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Support for RubyMine 2018.01 (via @kibitan)
 - Support for IntelliJ Idea 2017.1, 2017.2, 2017.3, and 2018.1 (via @cool00geek)
 - Remove references to OpenSSH private key syncing - removed in dcb26ba (via @njdancer)
+- Add logic to detect mackup config in iCloud (via @njdancer)
 
 ## Mackup 0.8.18
 

--- a/mackup/config.py
+++ b/mackup/config.py
@@ -179,7 +179,15 @@ class Config(object):
         if self._parser.has_option('storage', 'engine'):
             engine = str(self._parser.get('storage', 'engine'))
         else:
-            engine = ENGINE_DROPBOX
+            icloud_config_path = os.path.expanduser(os.path.join(
+                '~/Library/Mobile Documents/com~apple~CloudDocs',
+                MACKUP_BACKUP_PATH,
+                MACKUP_CONFIG_FILE))
+
+            if os.path.exists(icloud_config_path):
+                engine = ENGINE_ICLOUD
+            else:
+                engine = ENGINE_DROPBOX
 
         assert isinstance(engine, str)
 

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -35,6 +35,26 @@ class TestConfig(unittest.TestCase):
         assert cfg.apps_to_ignore == set()
         assert cfg.apps_to_sync == set()
 
+    def test_config_icloud_config_present(self):
+        realpath = os.path.dirname(os.path.realpath(__file__))
+        os.environ['HOME'] = os.path.join(realpath, 'fixtures/default-to-icloud')
+
+        cfg = Config()
+
+        # Should should do the same as the a standard iCloud configuration
+        assert isinstance(cfg.engine, str)
+        assert cfg.engine == ENGINE_ICLOUD
+
+        assert isinstance(cfg.path, str)
+        assert cfg.path == os.path.expanduser(
+            '~/Library/Mobile Documents/com~apple~CloudDocs/')
+
+        assert isinstance(cfg.directory, str)
+        assert cfg.directory == u'Mackup'
+
+        assert isinstance(cfg.fullpath, str)
+        assert cfg.fullpath.endswith(u'/com~apple~CloudDocs/Mackup')
+
     def test_config_empty(self):
         cfg = Config('mackup-empty.cfg')
 

--- a/tests/fixtures/default-to-icloud/Library/Mobile Documents/com~apple~CloudDocs/Mackup/.mackup.cfg
+++ b/tests/fixtures/default-to-icloud/Library/Mobile Documents/com~apple~CloudDocs/Mackup/.mackup.cfg
@@ -1,0 +1,2 @@
+[storage]
+engine = icloud


### PR DESCRIPTION
This update adds some logic to check iCloud Drive for a mackup config before defaulting to Dropbox. If found the default engine is set to iCloud allowing .mackup.cfg to be automatically linked. Otherwise Dropbox continues to be the default.