### PR TITLE
Add support for hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Support for RubyMine 2018.01 (via @kibitan)
 - Support for IntelliJ Idea 2017.1, 2017.2, 2017.3, and 2018.1 (via @cool00geek)
 - Remove references to OpenSSH private key syncing - removed in dcb26ba (via @njdancer)
+- Add support for hub (via @usami-k)
 
 ## Mackup 0.8.18
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Houdini](http://uglyapps.co.uk/houdini/)
 - [Htop](http://htop.sourceforge.net/)
 - [HTTPie](https://httpie.org/)
+- [hub](https://hub.github.com)
 - [Hyper.app](https://hyper.is/)
 - [HyperDock](https://bahoom.com/hyperdock)
 - [HyperSwitch](https://bahoom.com/hyperswitch)

--- a/mackup/applications/hub.cfg
+++ b/mackup/applications/hub.cfg
@@ -1,0 +1,5 @@
+[application]
+name = hub
+
+[configuration_files]
+.config/hub


### PR DESCRIPTION
[hub](https://hub.github.com) is the command line tool for github. 
This change will backup some configurations for hub.