### PR TITLE
Remove references for Visual Studio Code extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Support for IntelliJ Idea 2017.1, 2017.2, 2017.3, and 2018.1 (via @cool00geek)
 - Remove references to OpenSSH private key syncing - removed in dcb26ba (via @njdancer)
 - Add support for hub (via @usami-k)
+- Remove references for Visual Studio Code extensions syncing (via @MTalalAnwar)
 
 ## Mackup 0.8.18
 

--- a/mackup/applications/vscode.cfg
+++ b/mackup/applications/vscode.cfg
@@ -6,9 +6,6 @@ Library/Application Support/Code/User/snippets
 Library/Application Support/Code/User/keybindings.json
 Library/Application Support/Code/User/settings.json
 
-# user extensions
-.vscode/extensions
-
 # Linux Files
 .config/Code/User/snippets
 .config/Code/User/keybindings.json


### PR DESCRIPTION
Syncing Visual Studio Code extensions leads to bloatware. 

The references to the VSCode extensions sync the entire extensions directory which is completely redundant:

- VSCode extensions are basically `git clone` of their original repos. These references cause entire repositories to be synced. Syncing them is unnecessary because...
- ...VSCode extensions are customised by overriding their settings in the `settings.json` file, which is already being synced, there is no need to sync the extension the itself. The user can install the extensions themselves and a simple `mackup restore` would restore their custom settings for those extensions.

Example: My Mackup directory has 6,623 items (48.6MB), out of which 6,609 items (36MB) belong to the `.vscode/extensions` directory. I only have 4 extensions installed, you can imagine the impact that more extensions would cause.