### PR TITLE
Add support for asdf version manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Arm](https://www.atagar.com/arm/)
 - [Artistic Style](http://astyle.sourceforge.net)
 - [asciinema](https://asciinema.org/)
+- [asdf version manager](https://github.com/asdf-vm/asdf)
 - [Aspell](http://aspell.net/)
 - [Atlantis](http://www.riverdark.net/atlantis/)
 - [Atom](https://atom.io/)

--- a/mackup/applications/asdf.cfg
+++ b/mackup/applications/asdf.cfg
@@ -1,0 +1,6 @@
+[application]
+name = asdf
+
+[configuration_files]
+.asdfrc
+.tool-versions


### PR DESCRIPTION
Hi

I would like to add support for [asdf version manager](https://github.com/asdf-vm/asdf).

This change will sync 2 config files:
- `.asdfrc`, which contains configuration for asdf
- `.tool-version`, which is a global config for default plugin versions

Cheers