### PR TITLE
Support cVim, an extension that brings Vim bindings to Chrome.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Remove references to OpenSSH private key syncing - removed in dcb26ba (via @njdancer)
 - Add support for hub (via @usami-k)
 - Remove references for Visual Studio Code extensions syncing (via @MTalalAnwar)
+- Add support for cVim (via @sh78)
 
 ## Mackup 0.8.18
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [CoRD](http://cord.sourceforge.net/)
 - [CotEditor](http://coteditor.com/)
 - [Ctags](http://ctags.sourceforge.net/)
+- [cVim](https://github.com/1995eaton/chromium-vim)
 - [Cyberduck](https://cyberduck.io/)
 - [DaisyDisk](https://daisydiskapp.com)
 - [Dash](https://kapeli.com/dash)

--- a/mackup/applications/cvim.cfg
+++ b/mackup/applications/cvim.cfg
@@ -1,0 +1,5 @@
+[application]
+name = cVim
+
+[configuration_files]
+.cvimrc


### PR DESCRIPTION
cVim uses a [.cvimrc][1] file in the file system if the user has set
`localconfig`. The file can be placed anywhere, but it seems likely that most
people just drop it in `$HOME`.

[1]: https://github.com/1995eaton/chromium-vim#example-configuration