### PR TITLE
Add ~/Library locations for Mac Automator sources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add support for chunkwm (via @sh78)
 - Add support for cVim (via @sh78)
 - Add support for ESLint (via @sh78)
+- Improve coverage for macOS/OS X Automator files (via @sh78)
 
 ## Mackup 0.8.18
 

--- a/mackup/applications/macosx.cfg
+++ b/mackup/applications/macosx.cfg
@@ -4,4 +4,9 @@ name = MacOSX
 [configuration_files]
 .MacOSX
 Library/KeyBindings/DefaultKeyBinding.dict
+Library/PDF Services
 Library/Preferences/com.apple.symbolichotkeys.plist
+Library/Scripts
+Library/Services
+Library/Speech/Speakable Items
+Library/Workflows


### PR DESCRIPTION
This adds coverage for everything that one might create in Automator.
Make Use Of has a good [overview][makeuseof] of all of them, and Engaget
has a [list of where they get saved][engaget]. I verified these using
`fswatch` piped to `grep` while saving test projects.

Included in this change:

[Scripts]

    Library/Scripts

[Dictation Commands]

    Library/Speech/Speakable Items

[Services]

    Library/Services

[Workflows]

    Library/Workflows

Print Plugins

    Library/PDF Services

"Folder Actions" and "Calendar Alarms" are stored inside a sub
directories of ~/Library/Workflows/, and "Image Capture Plugins" are
stored in ~/Library/Scripts/.

[makeuseof]: https://www.makeuseof.com/tag/learn-mac-automator-handy-example-workflows/
[engaget]: https://www.engadget.com/2012/12/17/where-automator-actions-and-workflows-live/
[Scripts]: https://alvinalexander.com/blog/post/mac-os-x/where-put-applescript-program-script-directory-folder
[Dictation Commands]: https://lifehacker.com/dictate-any-command-to-you-mac-with-automator-1647672204
[Services]: https://www.makeuseof.com/tag/how-to-create-your-own-services-menus-mac/
[Workflows]: https://support.apple.com/guide/automator/aside/aut56b81a021/2.8/mac/10.13