### PR TITLE
feat(oh-my-zsh): add completions default folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Add support for PixelSnap (via @dnicolson)
 - Add support for Cider (via @renews)
 - Add support for Typora (via @allenlsy)
+- Improve support for oh-my-zsh (via @H--o-l)
 
 ## Mackup 0.8.18
 

--- a/mackup/applications/oh-my-zsh.cfg
+++ b/mackup/applications/oh-my-zsh.cfg
@@ -3,3 +3,4 @@ name = Oh My Zsh
 
 [configuration_files]
 .oh-my-zsh/custom
+.oh-my-zsh/completions


### PR DESCRIPTION
`oh-my-zsh` default folder for custom auto-completions is `.oh-my-zsh/completions` so I propose to add it.