### PR TITLE
Update mpv.cfg

### DIFF
--- a/mackup/applications/mpv.cfg
+++ b/mackup/applications/mpv.cfg
@@ -2,6 +2,7 @@
 name = MPV
 
 [configuration_files]
+.config/mpv/config
 .config/mpv/mpv.conf
 .config/mpv/scripts
 .config/mpv/input.conf


### PR DESCRIPTION
From the maintainer of `mpv` on macports:


> If you previously had your configuration file in
>    * ~/.mpv/config
>    please migrate it to
>    * ~/.config/mpv/config
>    which is the location preferred by upstream.