### PR TITLE
Add support for Adobe Illustrator CC2019 (v23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add support for xonsh (via @kmcm0)
 - Add support for Alacritty
 - Add support for WebStorm 2017.1, 2017.2, 2017.3, 2018.1, 2018.2 (via @KrzysztofKarol)
+- Add support for Adobe Illustrator CC2019 (v23)
 
 ## Mackup 0.8.19
 

--- a/mackup/applications/illustrator.cfg
+++ b/mackup/applications/illustrator.cfg
@@ -11,3 +11,21 @@ Library/Preferences/Adobe Illustrator 18 Settings
 Library/Preferences/Adobe Illustrator 19 Settings
 Library/Preferences/Adobe Illustrator 20 Settings
 Library/Preferences/com.adobe.illustrator.plist
+
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Adobe Illustrator Prefs
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Workspaces/
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Modified Workspaces/
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/DataRecovery
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Tools/Tools Panel Presets
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Print Presets
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Transparency flattener presets
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/VariableWidthProfiles
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Perspective grid Presets
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Vectorizing Presets
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Last Used Artboard Export Settings
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Last Used Asset Export Settings
+
+Library/Application Support/Adobe/Adobe Illustrator 23/en_US/Swatches/
+Library/Application Support/Adobe/Adobe Illustrator 23/en_US/Adobe SVG Filters.svg
+Library/Application Support/Adobe/OOBE

--- a/mackup/applications/illustrator.cfg
+++ b/mackup/applications/illustrator.cfg
@@ -15,7 +15,6 @@ Library/Preferences/com.adobe.illustrator.plist
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Adobe Illustrator Prefs
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Workspaces/
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Modified Workspaces/
-Library/Preferences/Adobe Illustrator 23 Settings/en_US/DataRecovery
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Tools/Tools Panel Presets
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Print Presets
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Transparency flattener presets


### PR DESCRIPTION
It was already in the readme as a supported application.

• I did some googling but could not find how OSX deals with ".localized" folders.

• I do wonder if the version number in these folders could be a variable?