### PR TITLE
Update support for i3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 
+- Update support for i3 (@KyleWJohnston)
 - Add support for bc (via @paxperscientiam)
 - Add support for Google clasp (via @paxperscientiam)
 - Add support for hstr (via @paxperscientiam)

--- a/README.md
+++ b/README.md
@@ -308,7 +308,6 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [HyperSwitch](https://bahoom.com/hyperswitch)
 - [i2cssh](https://github.com/wouterdebie/i2cssh)
 - [i3](https://i3wm.org/)
-- [i3wm](http://i3wm.org/)
 - [IdeaVim](https://github.com/JetBrains/ideavim)
 - [Inkscape](https://inkscape.org/)
 - [Insomnia](https://insomnia.rest/)

--- a/mackup/applications/i3.cfg
+++ b/mackup/applications/i3.cfg
@@ -3,4 +3,5 @@ name = i3
 
 [configuration_files]
 .i3/config
+.config/i3/config
 .i3status.conf


### PR DESCRIPTION
As stated in https://i3wm.org/docs/userguide.html#configuring, the i3
config file can be stored at either ~/.i3/config or ~/.config/i3/config.
i3.cfg has been updated to include the latter option in addition to the first.

README.md has two listings for i3, both pointing to the same website.
i3wm has been removed, leaving just i3 (the official name).