### PR TITLE
remove misleading sections from the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,6 @@ We can [with your help](doc#get-official-support-for-an-application) ;)
 Have an application that shouldn't be generally supported but that you use?
 Or a cool file you want to sync?
 
-- Use a `~/.mackup.cfg` to [sync a single file](doc#configuration) (e.g. `~/.gitignore`)
 - Create a `~/.mackup` directory to [sync an application or any file or directory](doc#add-support-for-an-application-or-any-file-or-directory)
 
 ## Why did you do this

--- a/doc/README.md
+++ b/doc/README.md
@@ -9,17 +9,6 @@ To configure Mackup, create a file named ´.mackup.cfg´ in your home directory.
 vi ~/.mackup.cfg
 ```
 
-Add personal files to sync by including the `configuration_files` header, e.g.
-
-```ini
-[configuration_files]
-.gitignore_global
-.config/your-custom-file
-```
-
-Note that Mackup assumes the file paths listed here are relative to your home
-directory.
-
 ## Storage
 
 ### Dropbox


### PR DESCRIPTION
which incorrectly suggest you can add a [configuration_files] section to ~/.mackup.cfg