### PR TITLE
Updated karabiner-elements.cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add support for b-ryan/powerline-shell (via @paxperscientiam)
 - Add support for kovidgoyal/kitty (via @foray1010)
 - Add support for PhpStorm 2018.2 (via @j13k)
+- Fix support for Karabiner Elements (via @mrymtsk)
 
 ## Mackup 0.8.20
 

--- a/mackup/applications/karabiner-elements.cfg
+++ b/mackup/applications/karabiner-elements.cfg
@@ -2,5 +2,4 @@
 name = Karabiner Elements
 
 [configuration_files]
-.config/karabiner/karabiner.json
-.config/karabiner/assets/complex_modifications
+.config/karabiner


### PR DESCRIPTION
Changed the config file so the whole ~/.config/karabiner directory will be backed up.
See: [Manual - Karabiner - Software for macOS](https://pqrs.org/osx/karabiner/document.html#configuration-file-path)