### PR TITLE
Fix support for Adobe Illustrator CC2019 (v23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for Storyist 3 writing software (via @mutantant)
 - Add support for WordGrinder (via @mutantant)
+- Fix support for Adobe Illustrator CC2019 (v23)
 
 ## Mackup 0.8.22
 

--- a/mackup/applications/illustrator.cfg
+++ b/mackup/applications/illustrator.cfg
@@ -13,7 +13,6 @@ Library/Preferences/Adobe Illustrator 17 Settings
 Library/Preferences/Adobe Illustrator 18 Settings
 Library/Preferences/Adobe Illustrator 19 Settings
 Library/Preferences/Adobe Illustrator 20 Settings
-Library/Preferences/Adobe Illustrator 23 Settings/en_US/
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Adobe Illustrator Prefs
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Last Used Artboard Export Settings
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Last Used Asset Export Settings


### PR DESCRIPTION
Changes introduced in #1243 result in `[Errno 2] No such file or directory` error because both the spcific directory and the files/subdirectories are listed in `[configuration_files]`.