### PR TITLE
Further fix for Adobe Illustrator CC2019 (v23)

### DIFF
--- a/mackup/applications/illustrator.cfg
+++ b/mackup/applications/illustrator.cfg
@@ -7,7 +7,7 @@ Library/Application Support/Adobe/Adobe Illustrator 18
 Library/Application Support/Adobe/Adobe Illustrator 19
 Library/Application Support/Adobe/Adobe Illustrator 20
 Library/Application Support/Adobe/Adobe Illustrator 23/en_US/Adobe SVG Filters.svg
-Library/Application Support/Adobe/Adobe Illustrator 23/en_US/Swatches/
+Library/Application Support/Adobe/Adobe Illustrator 23/en_US/Swatches
 Library/Application Support/Adobe/OOBE
 Library/Preferences/Adobe Illustrator 17 Settings
 Library/Preferences/Adobe Illustrator 18 Settings
@@ -16,12 +16,12 @@ Library/Preferences/Adobe Illustrator 20 Settings
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Adobe Illustrator Prefs
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Last Used Artboard Export Settings
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Last Used Asset Export Settings
-Library/Preferences/Adobe Illustrator 23 Settings/en_US/Modified Workspaces/
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Modified Workspaces
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Perspective grid Presets
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Print Presets
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Tools/Tools Panel Presets
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Transparency flattener presets
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/VariableWidthProfiles
 Library/Preferences/Adobe Illustrator 23 Settings/en_US/Vectorizing Presets
-Library/Preferences/Adobe Illustrator 23 Settings/en_US/Workspaces/
+Library/Preferences/Adobe Illustrator 23 Settings/en_US/Workspaces
 Library/Preferences/com.adobe.illustrator.plist


### PR DESCRIPTION
Previous PR #1296 missed a commit to remove trailing slashes in `[configuration_files]` list, which also caused `[Errno 2] No such file or directory` error.