### PR TITLE
Fixes #1297;remove bundle directory from vim config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for Storyist 3 writing software (via @mutantant)
 - Add support for WordGrinder (via @mutantant)
 - Fix support for Adobe Illustrator CC2019 (v23)
+- remove `bundle` directory from vim config (via @cocobear)
 
 ## Mackup 0.8.22
 

--- a/mackup/applications/vim.cfg
+++ b/mackup/applications/vim.cfg
@@ -6,7 +6,6 @@ name = Vim
 .gvimrc.after
 .gvimrc.before
 .vim/autoload
-.vim/bundle
 .vim/colors
 .vim/doc
 .vim/ftdetect


### PR DESCRIPTION
We should follow the principle:

> - The configuration should sync the minimal set of data, so that syncing happens quickly. Leave large app data out of the sync configuration.
