### PR TITLE
Support more folders in TextMate

### DIFF
--- a/mackup/applications/textmate.cfg
+++ b/mackup/applications/textmate.cfg
@@ -2,6 +2,9 @@
 name = TextMate
 
 [configuration_files]
+Library/Application Support/TextMate/Bundles
+Library/Application Support/TextMate/PlugIns
+Library/Application Support/TextMate/Pristine Copy
 Library/Application Support/TextMate/Managed/Bundles
 Library/Preferences/com.macromates.textmate.plist
 Library/Preferences/com.macromates.textmate.latex_config.plist


### PR DESCRIPTION
Only symlinking `Managed/Bundles` is not enough. TextMate uses 3 more folders that may contain bundles or plugins.

- `Library/Application Support/TextMate/Bundles`
cloned 3rd-party bundles are installed here.
- `Library/Application Support/TextMate/PlugIns`
plugins (for example EditorConfig)
- `Library/Application Support/TextMate/Pristine Copy`
also for 3rd-party bundles, but they are installed with a double-click