### PR TITLE
Ulauncher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 
+- Add support for ulauncher (via @sUyMur)
 - Add support for Tilix (via @pat-s)
 - Improve support for TextMate (via @egze)
 - Add support for Storyist 3 writing software (via @mutantant)

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Typinator](http://www.ergonis.com/products/typinator/)
 - [Typora](https://typora.io)
 - [uTorrent](http://www.utorrent.com/)
+- [ulauncher](https://ulauncher.io/)
 - [Ventrilo](http://www.ventrilo.com/)
 - [Versions](http://www.versionsapp.com)
 - [Vim](http://www.vim.org/)

--- a/mackup/applications/ubersicht.cfg
+++ b/mackup/applications/ubersicht.cfg
@@ -4,4 +4,3 @@ name = Ubersicht
 [configuration_files]
 Library/Application Support/Übersicht/widgets
 Library/Preferences/tracesOf.Uebersicht.plist
-Library/Preferences/test.Uebersicht.plist

--- a/mackup/applications/ubersicht.cfg
+++ b/mackup/applications/ubersicht.cfg
@@ -4,3 +4,4 @@ name = Ubersicht
 [configuration_files]
 Library/Application Support/Übersicht/widgets
 Library/Preferences/tracesOf.Uebersicht.plist
+Library/Preferences/test.Uebersicht.plist

--- a/mackup/applications/ulauncher.cfg
+++ b/mackup/applications/ulauncher.cfg
@@ -1,5 +1,5 @@
 [application]
-name = ulauncher
+name = Ulauncher
 
 [configuration_files]
 .config/ulauncher/extensions.json

--- a/mackup/applications/ulauncher.cfg
+++ b/mackup/applications/ulauncher.cfg
@@ -1,0 +1,7 @@
+[application]
+name = ulauncher
+
+[configuration_files]
+.config/ulauncher/extensions.json
+.config/ulauncher/settings.json
+.config/ulauncher/shortcuts.json


### PR DESCRIPTION
Testing it the described way (link below) didn't work (didn't include the new cfg for some reason). 
Adding ulauncher.cfg to ~/.mackup resulted in a successful backup.

https://github.com/lra/mackup/tree/master/doc#locally-test-an-application-before-submitting-a-pull-request