### PR TITLE
Including .wget-hsts file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add support for Goldendict (via @krupenja)
 - Add support for IINA (via @krupenja)
 - Improve support for fish (via @whtsky)
+- Improve support for weget (via @paxperscientiam)
 
 ## Mackup 0.8.22
 

--- a/mackup/applications/wget.cfg
+++ b/mackup/applications/wget.cfg
@@ -3,3 +3,4 @@ name = Wget
 
 [configuration_files]
 .wgetrc
+.wget-hsts


### PR DESCRIPTION
> By default, Wget stores its HSTS database in ~/.wget-hsts. You can use ‘--hsts-file’ to override this. Wget will use the supplied file as the HSTS database. Such file must conform to the correct HSTS database format used by Wget. If Wget cannot parse the provided file, the behaviour is unspecified. 

https://www.gnu.org/software/wget/manual/html_node/HTTPS-_0028SSL_002fTLS_0029-Options.html