### PR TITLE
Fix TextMate com.macromates.textmate.plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 
+- Remove problematic com.macromates.textmate.plist file for TextMate (via @egze)
 - Add support for rofi (via @pat-s)
 - Add support for deepin-dde-file-manager (via @sUyMur)
 - Add support for Deepin-dde-dock (via @sUyMur)

--- a/mackup/applications/textmate.cfg
+++ b/mackup/applications/textmate.cfg
@@ -6,6 +6,5 @@ Library/Application Support/TextMate/Bundles
 Library/Application Support/TextMate/PlugIns
 Library/Application Support/TextMate/Pristine Copy
 Library/Application Support/TextMate/Managed/Bundles
-Library/Preferences/com.macromates.textmate.plist
 Library/Preferences/com.macromates.textmate.latex_config.plist
 .tm_properties


### PR DESCRIPTION
Syncing `Library/Preferences/com.macromates.textmate.plist` doesn't work reliably between 2 machines. 

I'm constantly getting lots of files like this in Dropbox:
`com.macromates.textmate (Aleksandrs-iMac.local's conflicted copy 2019-03-01).plist`

I think it's best to just ignore this file. It doesn't store anything important anyway.