### PR TITLE
Vim add after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 
+- Improve support for Vim, add .vim/after directory
 - Remove problematic com.macromates.textmate.plist file for TextMate (via @egze)
 - Add support for rofi (via @pat-s)
 - Add support for deepin-dde-file-manager (via @sUyMur)

--- a/mackup/applications/vim.cfg
+++ b/mackup/applications/vim.cfg
@@ -6,6 +6,7 @@ name = Vim
 .gvimrc.after
 .gvimrc.before
 .vim/autoload
+.vim/after
 .vim/colors
 .vim/doc
 .vim/ftdetect


### PR DESCRIPTION
Ref Issue #1334 

The .vim/after directory is part of pristine Vim. It contains the files sourced last, used for overriding plugin settings e.g. Thus, it should be synced together with the other folders.