### PR TITLE
Revert "Remove support for iTunes Scripts"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - Add support for WordGrinder (via @mutantant)
 - Fix support for Adobe Illustrator CC2019 (v23)
 - remove `bundle` directory from vim config (via @cocobear)
-- Remove iTunes Scripts (via @dnicolson)
 - Add support for Sublime Merge (via @krupenja)
 - Add support for Marta (via @krupenja)
 - Add support for Goldendict (via @krupenja)

--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [zathura](https://pwmt.org/projects/zathura/)
 - [Zsh](http://zsh.sourceforge.net/)
 - [Übersicht](http://tracesof.net/uebersicht/)
+- iTunes Applescripts
 
 ## Can you support application X
 

--- a/mackup/applications/itunesscripts.cfg
+++ b/mackup/applications/itunesscripts.cfg
@@ -1,0 +1,5 @@
+[application]
+name = iTunesScripts
+
+[configuration_files]
+Library/iTunes/Scripts


### PR DESCRIPTION
Reverts lra/mackup#1311.

This has been fixed in macOS 10.4.4.