### PR TITLE
Prevent users to use Mackup's storage directory to store their files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Prevent users to use Mackup's storage directory to store their files.
+
 ## Mackup 0.8.23
 
 - Improve support for Vim, add .vim/after directory

--- a/mackup/config.py
+++ b/mackup/config.py
@@ -3,7 +3,8 @@
 import os
 import os.path
 
-from .constants import (MACKUP_BACKUP_PATH,
+from .constants import (CUSTOM_APPS_DIR,
+                        MACKUP_BACKUP_PATH,
                         MACKUP_CONFIG_FILE,
                         ENGINE_DROPBOX,
                         ENGINE_GDRIVE,
@@ -228,6 +229,10 @@ class Config(object):
         """
         if self._parser.has_option('storage', 'directory'):
             directory = self._parser.get('storage', 'directory')
+            # Don't allow CUSTOM_APPS_DIR as a storage directory
+            if directory == CUSTOM_APPS_DIR:
+                raise ConfigError("{} cannot be used as a storage directory."
+                                  .format(CUSTOM_APPS_DIR))
         else:
             directory = MACKUP_BACKUP_PATH
 


### PR DESCRIPTION
Fix #1358