### PR TITLE
Add .vim/spell folder for custom words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added support for git ignore file
 - Added default ignore file for eslint
+- Improve support for Vim, add .vim/spell folder
 
 ## Mackup 0.8.24
 

--- a/mackup/applications/vim.cfg
+++ b/mackup/applications/vim.cfg
@@ -14,6 +14,7 @@ name = Vim
 .vim/indent
 .vim/pack
 .vim/plugin/settings
+.vim/spell
 .vim/syntax
 .vim/vimrc
 .vimrc


### PR DESCRIPTION
http://vimdoc.sourceforge.net/htmldoc/options.html#'spellfile'
Note that apparently only *.add files are needed, and *.spl files are generated from them. Added the folder since AFAIK there is no support for wildcards yet.