### PR TITLE
Add support for Apple Music scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added default ignore file for eslint
 - Improve support for Vim, add .vim/spell folder
 - Add support for PixelSnap 2 (via @dnicolson)
+- Add support for Apple Music Scripts (via @dnicolson)
 
 ## Mackup 0.8.24
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [AppCleaner](http://freemacsoft.net/appcleaner/)
 - [AppCode](http://www.jetbrains.com/objc/)
 - [Apptivate](http://www.apptivateapp.com/)
+- [Apple Music Scripts](https://www.apple.com/)
 - [Arara](https://github.com/cereda/arara)
 - [aria2c](http://aria2.sourceforge.net/)
 - [Arm](https://www.atagar.com/arm/)

--- a/mackup/applications/apple-music-scripts.cfg
+++ b/mackup/applications/apple-music-scripts.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Apple Music Scripts
+
+[configuration_files]
+Library/Music/Scripts


### PR DESCRIPTION
This pull request adds support for scripts in the macOS 10.15 Apple Music app.

> The Music.app Script Menu Lives! Simply create the “Music/Scripts/” folders in the Library folder, put at least one script in it and the Script menu will appear in Music.app. I haven’t tried this with the Apple TV app, but I’m betting it works the same.

https://dougscripts.com/itunes/2019/06/first-thoughts-about-music-app/