### PR TITLE
added config file for pnpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added default ignore file for eslint
 - Improve support for Vim, add .vim/spell folder
 - Add support for PixelSnap 2 (via @dnicolson)
+- Add support for pnpm (via @paxperscientiam)
 
 ## Mackup 0.8.24
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [PIP](http://www.pip-installer.org/)
 - [PixelSnap](https://getpixelsnap.com/)
 - [PixelSnap 2](https://getpixelsnap.com/)
+- [Pnpm](https://pnpm.js.org/)
 - [Pock](https://pock.pigigaldi.com)
 - [Poedit](http://poedit.net/)
 - [PokerStars](https://www.pokerstars.com/)

--- a/mackup/applications/pnpm.cfg
+++ b/mackup/applications/pnpm.cfg
@@ -1,0 +1,6 @@
+[application]
+name = pnpm
+
+[configuration_files]
+.pnpm/global_pnpmfile.js
+.pnpm-store/2/store.json


### PR DESCRIPTION
Hey @lra , i have a question. In addition to the files I've marked in the new config file, the pnpm folks indicate that settings are read from npm config files. I decided not to include those as I'm guessing you can't have two config files pointing to the same program config file. Is that accurate?

This address #1389 