### PR TITLE
Add support for ripgrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Added support for Bat (via @joshmedeski)
+- Added support for ripgrep (via @dnicolson)
 
 ## Mackup 0.8.27
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Redshift](http://jonls.dk/redshift/)
 - [Rhythmbox](https://wiki.gnome.org/Apps/Rhythmbox)
 - [Rime](http://rime.im/)
+- [ripgrep](https://github.com/BurntSushi/ripgrep)
 - [Robomongo](http://robomongo.org/)
 - [Rofi](https://github.com/DaveDavenport/rofi)
 - [Royal TSX](http://www.royaltsx.com/ts/osx/features)

--- a/mackup/applications/ripgrep.cfg
+++ b/mackup/applications/ripgrep.cfg
@@ -1,0 +1,5 @@
+[application]
+name = ripgrep
+
+[configuration_files]
+.ripgreprc


### PR DESCRIPTION
This pull request adds support for the ripgrep [configuration file](https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file).