### PR TITLE
Add ability to backup "defaults" settings

### DIFF
--- a/doc/.mackup.cfg
+++ b/doc/.mackup.cfg
@@ -41,6 +41,12 @@ engine = dropbox
 # engine you chose, e.g. "~/Dropbox/Mackup".
 directory = Mackup
 
+
+# You can customize the directory name in which Mackup stores your "defaults" configurations. By
+# default, if not specified, Mackup creates a "Defaults" directory in the storage
+# engine you chose, e.g. "~/Dropbox/Defaults".
+defaults_directory = Defaults
+
 # List of applications you want to explicitly sync
 # One application name per line
 # If this list is empty, Mackup will try to sync all the supported

--- a/doc/README.md
+++ b/doc/README.md
@@ -76,7 +76,7 @@ path = some/path in your/home
 path = /some path/in/your/root
 ```
 
-### Custom Directory Name
+### Custom Directory Names
 
 You can customize the directory name in which Mackup stores your file. By
 default, if not specified, Mackup creates a `Mackup` directory in the storage
@@ -105,6 +105,35 @@ You can also select a subfolder:
 engine = icloud
 directory = .config/mackup
 ```
+
+You can also customize the directory name in which Mackup stores your "defaults" settings. By
+default, if not specified, Mackup creates a `Defaults` directory in the storage
+engine you chose, e.g. `~/Dropbox/Defaults`.
+
+```ini
+[storage]
+defaults_directory = Defaults
+```
+
+For example:
+
+```ini
+[storage]
+engine = file_system
+path = dotfiles
+defaults_directory = defaults
+```
+
+This will store your files in the `~/dotfiles/defaults` directory in your home.
+
+You can also select a subfolder:
+
+```ini
+[storage]
+engine = icloud
+defaults_directory = .config/defaults
+```
+
 
 ## Applications
 
@@ -185,11 +214,15 @@ name = Nethack
 ```bash
 $ cat ~/.mackup/my-files.cfg
 [application]
-name = My personal synced files and dirs
+name = My personal synced files, dirs, and defaults settings
 
 [configuration_files]
 bin
 .hidden
+
+[defaults_domains]
+nl.stickybits.OTP-Manager
+
 ```
 
 You can run mackup to see if they are listed

--- a/doc/README.md
+++ b/doc/README.md
@@ -106,9 +106,9 @@ engine = icloud
 directory = .config/mackup
 ```
 
-You can also customize the directory name in which Mackup stores your "defaults" settings. By
-default, if not specified, Mackup creates a `Defaults` directory in the storage
-engine you chose, e.g. `~/Dropbox/Defaults`.
+You can also customize the directory name in which Mackup stores your "defaults"
+settings. By default, if not specified, Mackup creates a `Defaults` directory in
+the storage engine you chose, e.g. `~/Dropbox/Defaults`.
 
 ```ini
 [storage]
@@ -133,7 +133,6 @@ You can also select a subfolder:
 engine = icloud
 defaults_directory = .config/defaults
 ```
-
 
 ## Applications
 

--- a/mackup/application.py
+++ b/mackup/application.py
@@ -5,6 +5,7 @@ An Application Profile contains all the information about an application in
 Mackup. Name, files, ...
 """
 import os
+import subprocess
 import sys
 
 from .mackup import Mackup
@@ -60,7 +61,7 @@ class ApplicationProfile(object):
         """
         return (
             domain,
-            os.path.join(self.mackup.mackup_folder, domain + ".plist"),
+            os.path.join(self.mackup.defaults_folder, domain + ".plist"),
         )
 
     def backup(self):
@@ -170,7 +171,8 @@ class ApplicationProfile(object):
         for domain in self.domains:
             (domain_name, defaults_filepath) = self.getDomainpaths(domain)
             try:
-                p = os.subprocess.run(["defaults", "export", domain_name, defaults_filepath], capture_output=True)
+                print("Exporting defaults to ", defaults_filepath)
+                p = subprocess.run(["defaults", "export", domain_name, defaults_filepath], capture_output=True)
                 if p.returncode != 0:
                     print("Defaults Export returned ", p.returncode, file=sys.stderr)
                     print("Output was: ", p.stderr, file=sys.stderr)
@@ -281,7 +283,7 @@ class ApplicationProfile(object):
 
             if plist_file__exists:
                 try:
-                    p = os.subprocess.run(["defaults", "import", domain_name, defaults_filepath], capture_output=True)
+                    p = subprocess.run(["defaults", "import", domain_name, defaults_filepath], capture_output=True)
                     if p.returncode != 0:
                         print("Defaults Import returned ", p.returncode, file=sys.stderr)
                         print("Output was: ", p.stderr, file=sys.stderr)

--- a/mackup/application.py
+++ b/mackup/application.py
@@ -7,6 +7,8 @@ Mackup. Name, files, ...
 import os
 import subprocess
 import sys
+import platform
+from . import constants
 
 from .mackup import Mackup
 from . import utils
@@ -167,6 +169,10 @@ class ApplicationProfile(object):
             defaults export domain mackup/file
 
         """
+        # This will not work on Linux as it has no concept of defaults
+        if platform.system() != constants.PLATFORM_DARWIN:
+            return
+
         # For each file used by the application
         for domain in self.domains:
             (domain_name, defaults_filepath) = self.getDomainpaths(domain)
@@ -275,6 +281,11 @@ class ApplicationProfile(object):
                 defaults import domain mackup/file
 
         """
+
+        # This will not work on Linux as it has no concept of defaults
+        if platform.system() != constants.PLATFORM_DARWIN:
+            return
+
         # For each file used by the application
         for domain in self.domains:
             (domain_name, defaults_filepath) = self.getDomainpaths(domain)

--- a/mackup/appsdb.py
+++ b/mackup/appsdb.py
@@ -44,6 +44,12 @@ class ApplicationsDatabase(object):
                 app_pretty_name = config.get("application", "name")
                 self.apps[app_name]["name"] = app_pretty_name
 
+                # Add the defaults domains to sync
+                self.apps[app_name]["defaults_domains"] = set()
+                if config.has_section("defaults_domains"):
+                    for domain in config.options("defaults_domains"):
+                        self.apps[app_name]["defaults_domains"].add(domain)
+
                 # Add the configuration files to sync
                 self.apps[app_name]["configuration_files"] = set()
                 if config.has_section("configuration_files"):
@@ -139,6 +145,18 @@ class ApplicationsDatabase(object):
             set of str.
         """
         return self.apps[name]["configuration_files"]
+
+    def get_domains(self, name):
+        """
+        Return the list of defaults domains of an application.
+
+        Args:
+            name (str)
+
+        Returns:
+            set of str.
+        """
+        return self.apps[name]["defaults_domains"]
 
     def get_app_names(self):
         """

--- a/mackup/config.py
+++ b/mackup/config.py
@@ -13,7 +13,7 @@ from .constants import (
     ENGINE_ICLOUD,
     ENGINE_BOX,
     ENGINE_FS,
-)
+    MACKUP_DEFAULTS_BACKUP_PATH)
 
 from .utils import (
     error,
@@ -59,6 +59,9 @@ class Config(object):
         # Get the directory replacing 'Mackup', if any
         self._directory = self._parse_directory()
 
+        # Get the defaults directory, replacing "Defaults" if necessary
+        self._defaults_directory = self._parse_defaults_directory()
+
         # Get the list of apps to ignore
         self._apps_to_ignore = self._parse_apps_to_ignore()
 
@@ -102,6 +105,16 @@ class Config(object):
         return str(self._directory)
 
     @property
+    def defaults_directory(self):
+        """
+        The name of the Defaults directory, named Defaults by default.
+
+        Returns:
+            str
+        """
+        return str(self._defaults_directory)
+
+    @property
     def fullpath(self):
         """
         Full path to the Mackup configuration files.
@@ -113,6 +126,19 @@ class Config(object):
             str
         """
         return str(os.path.join(self.path, self.directory))
+
+    @property
+    def defaults_fullpath(self):
+        """
+        Full path to the Defaults configuration files.
+
+        The full path to the directory when Mackup is storing the Defaults
+        files.
+
+        Returns:
+            str
+        """
+        return str(os.path.join(self.path, self.defaults_directory))
 
     @property
     def apps_to_ignore(self):
@@ -248,6 +274,26 @@ class Config(object):
             directory = MACKUP_BACKUP_PATH
 
         return str(directory)
+
+    def _parse_defaults_directory(self):
+        """
+        Parse the defaults storage directory in the config.
+
+        Returns:
+            str
+        """
+        if self._parser.has_option("storage", "defaults_directory"):
+            directory = self._parser.get("storage", "defaults_directory")
+            # Don't allow CUSTOM_APPS_DIR as a defaults storage directory
+            if directory == CUSTOM_APPS_DIR:
+                raise ConfigError(
+                    "{} cannot be used as a defaults storage directory.".format(CUSTOM_APPS_DIR)
+                )
+        else:
+            directory = MACKUP_DEFAULTS_BACKUP_PATH
+
+        return str(directory)
+
 
     def _parse_apps_to_ignore(self):
         """

--- a/mackup/config.py
+++ b/mackup/config.py
@@ -6,6 +6,7 @@ import os.path
 from .constants import (
     CUSTOM_APPS_DIR,
     MACKUP_BACKUP_PATH,
+    MACKUP_DEFAULTS_BACKUP_PATH,
     MACKUP_CONFIG_FILE,
     ENGINE_DROPBOX,
     ENGINE_GDRIVE,
@@ -13,7 +14,7 @@ from .constants import (
     ENGINE_ICLOUD,
     ENGINE_BOX,
     ENGINE_FS,
-    MACKUP_DEFAULTS_BACKUP_PATH)
+)
 
 from .utils import (
     error,

--- a/mackup/constants.py
+++ b/mackup/constants.py
@@ -1,6 +1,6 @@
 """Constants used in Mackup."""
 # Current version
-VERSION = "0.8.27"
+VERSION = "0.8.27-with-defaults"
 
 # Support platforms
 PLATFORM_DARWIN = "Darwin"
@@ -14,6 +14,7 @@ MACKUP_APP_NAME = "mackup"
 
 # Default Mackup backup path where it stores its files in Dropbox
 MACKUP_BACKUP_PATH = "Mackup"
+MACKUP_DEFAULTS_BACKUP_PATH = "Defaults"
 
 # Mackup config file
 MACKUP_CONFIG_FILE = ".mackup.cfg"

--- a/mackup/constants.py
+++ b/mackup/constants.py
@@ -1,6 +1,6 @@
 """Constants used in Mackup."""
 # Current version
-VERSION = "0.8.27-with-defaults"
+VERSION = "0.8.27"
 
 # Support platforms
 PLATFORM_DARWIN = "Darwin"

--- a/mackup/mackup.py
+++ b/mackup/mackup.py
@@ -24,6 +24,8 @@ class Mackup(object):
         self._config = config.Config()
 
         self.mackup_folder = self._config.fullpath
+        self.defaults_folder = self._config.defaults_fullpath
+
         self.temp_folder = tempfile.mkdtemp(prefix="mackup_tmp_")
 
     def check_for_usable_environment(self):
@@ -64,6 +66,13 @@ class Mackup(object):
                 " storage directory synced first.".format(self.mackup_folder)
             )
 
+        if not os.path.isdir(self.defaults_folder):
+            utils.error(
+                "Unable to find the Defaults folder: {}\n"
+                "You might want to back up some files or get your"
+                " storage directory synced first.".format(self.defaults_folder)
+            )
+
     def clean_temp_folder(self):
         """Delete the temp folder and files created while running."""
         shutil.rmtree(self.temp_folder)
@@ -79,6 +88,16 @@ class Mackup(object):
                 os.makedirs(self.mackup_folder)
             else:
                 utils.error("Mackup can't do anything without a home =(")
+
+        if not os.path.isdir(self.defaults_folder):
+            if utils.confirm(
+                "Mackup needs a directory to store your"
+                " defaults files\n"
+                "Do you want to create it now? <{}>".format(self.defaults_folder)
+            ):
+                os.makedirs(self.defaults_folder)
+            else:
+                utils.error("Mackup can't do anything without a defaults home =(")
 
     def get_apps_to_backup(self):
         """

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -83,9 +83,10 @@ def main():
 
         # Backup each application
         for app_name in sorted(mckp.get_apps_to_backup()):
-            app = ApplicationProfile(mckp, app_db.get_files(app_name), dry_run, verbose)
+            app = ApplicationProfile(mckp, app_db.get_files(app_name), app_db.get_domains(app_name), dry_run, verbose)
             printAppHeader(app_name)
             app.backup()
+            app.backup_defaults()
 
     elif args["restore"]:
         # Check the env where the command is being run
@@ -94,7 +95,7 @@ def main():
         # Restore the Mackup config before any other config, as we might need
         # it to know about custom settings
         mackup_app = ApplicationProfile(
-            mckp, app_db.get_files(MACKUP_APP_NAME), dry_run, verbose
+            mckp, app_db.get_files(MACKUP_APP_NAME), app_db.get_domains(MACKUP_APP_NAME), dry_run, verbose
         )
         printAppHeader(MACKUP_APP_NAME)
         mackup_app.restore()
@@ -110,9 +111,10 @@ def main():
         app_names.discard(MACKUP_APP_NAME)
 
         for app_name in sorted(app_names):
-            app = ApplicationProfile(mckp, app_db.get_files(app_name), dry_run, verbose)
+            app = ApplicationProfile(mckp, app_db.get_files(app_name), app_db.get_domains(app_name), dry_run, verbose)
             printAppHeader(app_name)
             app.restore()
+            app.restore_defaults()
 
     elif args["uninstall"]:
         # Check the env where the command is being run
@@ -135,7 +137,7 @@ def main():
 
             for app_name in sorted(app_names):
                 app = ApplicationProfile(
-                    mckp, app_db.get_files(app_name), dry_run, verbose
+                    mckp, app_db.get_files(app_name), app_db.get_domains(app_name), dry_run, verbose
                 )
                 printAppHeader(app_name)
                 app.uninstall()
@@ -143,7 +145,7 @@ def main():
             # Restore the Mackup config before any other config, as we might
             # need it to know about custom settings
             mackup_app = ApplicationProfile(
-                mckp, app_db.get_files(MACKUP_APP_NAME), dry_run, verbose
+                mckp, app_db.get_files(MACKUP_APP_NAME), app_db.get_domains(app_name), dry_run, verbose
             )
             mackup_app.uninstall()
 
@@ -183,6 +185,9 @@ def main():
         print ("Configuration files:")
         for file in app_db.get_files(app_name):
             print (" - {}".format(file))
+        print ("Defaults domains:")
+        for domain in app_db.get_domains(app_name):
+            print (" - {}".format(domain))
 
     # Delete the tmp folder
     mckp.clean_temp_folder()


### PR DESCRIPTION
Some applications, e.g. OTP Manager, Vanilla, etc. do not have config files but save their configuration using the Mac OS "defaults" system, e.g. "defaults write nl.stickybits.OTP-Manager <some-key> <some-value>"
This PR adds the ability to backup and restore the settings of such applications in the same way as backing up and restoring configuration files. 