### PR TITLE
Added support for XVim

### DIFF
--- a/mackup/applications/xvim.cfg
+++ b/mackup/applications/xvim.cfg
@@ -1,0 +1,6 @@
+[application]
+name = XVim
+
+[configuration_files]
+.xvimrc
+


### PR DESCRIPTION
This adds support for Xvim, the vim keybindings plugin for Xcode. Both [XVim](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=9&cad=rja&uact=8&ved=2ahUKEwic3YKB16nlAhVFHzQIHdX-B9gQFjAIegQIARAB&url=https%3A%2F%2Fgithub.com%2FXVimProject%2FXVim&usg=AOvVaw1q579BisG2OBdYednvi1B_) (very outdated at this point, but may still be used by some for very old versions of xcode) and [XVim2](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=10&cad=rja&uact=8&ved=2ahUKEwic3YKB16nlAhVFHzQIHdX-B9gQFjAJegQIABAB&url=https%3A%2F%2Fgithub.com%2FXVimProject%2FXVim2&usg=AOvVaw2D6jPJt0_X3SshQ_3sajyk) use the same .xvimrc as a config file, so this should work for both.