### PR TITLE
Add support for WebStorm 2019 and (hopefully) WebStorm 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## WIP
 
 - Added support for Bat (via @joshmedeski)
-- Added support for WebStorm versions 2019.1 and 2019.2
+- Added support for WebStorm versions 2019.1, 2019.2 and 2019.3
+- Added support for WebStorm versions 2020.1, 2020.2 and 2020.3 (assuming they use the same directory structure as previous editions)
 
 ## Mackup 0.8.27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Added support for Bat (via @joshmedeski)
+- Added support for WebStorm versions 2019.1 and 2019.2
 
 ## Mackup 0.8.27
 

--- a/mackup/applications/webstorm.cfg
+++ b/mackup/applications/webstorm.cfg
@@ -32,3 +32,11 @@ Library/Application Support/WebStorm2019.1
 Library/Preferences/WebStorm2019.1
 Library/Application Support/WebStorm2019.2
 Library/Preferences/WebStorm2019.2
+Library/Application Support/WebStorm2019.3
+Library/Preferences/WebStorm2019.3
+Library/Application Support/WebStorm2020.1
+Library/Preferences/WebStorm2020.1
+Library/Application Support/WebStorm2020.2
+Library/Preferences/WebStorm2020.2
+Library/Application Support/WebStorm2020.3
+Library/Preferences/WebStorm2020.3

--- a/mackup/applications/webstorm.cfg
+++ b/mackup/applications/webstorm.cfg
@@ -28,3 +28,7 @@ Library/Application Support/WebStorm2018.2
 Library/Preferences/WebStorm2018.2
 Library/Application Support/WebStorm2018.3
 Library/Preferences/WebStorm2018.3
+Library/Application Support/WebStorm2019.1
+Library/Preferences/WebStorm2019.1
+Library/Application Support/WebStorm2019.2
+Library/Preferences/WebStorm2019.2


### PR DESCRIPTION
As well as adding the already-released 2019 versions, I put entries in for 2020.1, 2020.2 and 2020.3, which should work as long as they don't change the folder naming convention they've used in previous versions.