### PR TITLE
Add support for Vivaldi Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Ventrilo](http://www.ventrilo.com/)
 - [Versions](http://www.versionsapp.com)
 - [Vim](http://www.vim.org/)
+- [Vivaldi](https://vivaldi.com/)
 - [Vimperator](http://www.vimperator.org/vimperator)
 - [Viscosity](http://www.sparklabs.com/viscosity/)
 - [Visual Studio Code - Insiders](https://code.visualstudio.com/insiders)

--- a/mackup/applications/vivaldi.cfg
+++ b/mackup/applications/vivaldi.cfg
@@ -2,4 +2,4 @@
 name = Vivaldi
 
 [configuration_files]
-Library/Application Support/Vivaldi
+Library/Application Support/Vivaldi/Default

--- a/mackup/applications/vivaldi.cfg
+++ b/mackup/applications/vivaldi.cfg
@@ -1,0 +1,6 @@
+[application]
+name = Vivaldi
+
+[configuration_files]
+Library/Application Support/Vivaldi
+

--- a/mackup/applications/vivaldi.cfg
+++ b/mackup/applications/vivaldi.cfg
@@ -3,4 +3,3 @@ name = Vivaldi
 
 [configuration_files]
 Library/Application Support/Vivaldi
-


### PR DESCRIPTION
Caches of Vivaldi located in Library/Caches/Vivaldi
It sync all of session data with extension settings and some of the settings that are not synced via Vivaldi sync