### PR TITLE
Update support for marta 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Added support for Bat (via @joshmedeski)
+- Updated support for Marta to capture new config files in 0.6.1 (via @petrbouchal)
 
 ## Mackup 0.8.27
 

--- a/mackup/applications/marta.cfg
+++ b/mackup/applications/marta.cfg
@@ -4,3 +4,6 @@ name = Marta
 [configuration_files]
 Library/Application Support/org.yanex.marta/conf.json
 Library/Application Support/org.yanex.marta/favorites.json
+Library/Application Support/org.yanex.marta/conf.marco
+Library/Application Support/org.yanex.marta/favorites.marco
+

--- a/mackup/applications/marta.cfg
+++ b/mackup/applications/marta.cfg
@@ -6,4 +6,3 @@ Library/Application Support/org.yanex.marta/conf.json
 Library/Application Support/org.yanex.marta/favorites.json
 Library/Application Support/org.yanex.marta/conf.marco
 Library/Application Support/org.yanex.marta/favorites.marco
-


### PR DESCRIPTION
In 0.6.1 (Feb 2019) the file format and extension for the config files [changed from `json` to `marco`](https://marta.yanex.org/blog/introducing-marco/).

This PR adds these new files to the config file while leaving the original ones to preserve backward compatibility.