### PR TITLE
Add VSCode Extension support

### DIFF
--- a/mackup/applications/vscode.cfg
+++ b/mackup/applications/vscode.cfg
@@ -10,3 +10,5 @@ Library/Application Support/Code/User/settings.json
 .config/Code/User/snippets
 .config/Code/User/keybindings.json
 .config/Code/User/settings.json
+
+.vscode/extensions


### PR DESCRIPTION
Is there a particular reason that `mackup` doesn't backup VSCode extensions since that's needed to transport a total VSCode configuration?

https://code.visualstudio.com/docs/editor/extension-gallery#_common-questions

Extensions on MacOS/Linux are stored in `.vscode/extensions`.