### PR TITLE
Added support for AndroidStudio3.3 & Pet

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Pear](http://pear.php.net/)
 - [Pentadactyl](http://5digits.org/pentadactyl/)
 - [Perl](https://www.perl.org/)
+- [Pet](https://github.com/knqyf263/pet)
 - [Phoenix](https://github.com/kasper/phoenix)
 - [PhoneView](https://www.ecamm.com/mac/phoneview/)
 - [PhpStorm](http://www.jetbrains.com/phpstorm/)

--- a/mackup/applications/androidstudio-33.cfg
+++ b/mackup/applications/androidstudio-33.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Android Studio 3.3
+
+[configuration_files]
+Library/Preferences/AndroidStudio3.3

--- a/mackup/applications/pet.cfg
+++ b/mackup/applications/pet.cfg
@@ -1,0 +1,5 @@
+[application]
+name = pet
+
+[configuration_files]
+.config/pet


### PR DESCRIPTION
I'm not sure how things were back when `Library/Application Support/AndroidStudio1.3` was considered for "Android Studio 1.3". But `Library/Application Support/AndroidStudio3.3` takes close to 100MBs in my case and none of the files looked worthy of backup. They were mostly downloaded content.