### PR TITLE
Add support for Rectangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Added support for Bat (via @joshmedeski)
+- Added support for Rectangle (via @arvindch)
 
 ## Mackup 0.8.27
 

--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [R](http://www.r-project.org/)
 - [Rails](http://rubyonrails.org/)
 - [Ranger](https://ranger.github.io/)
+- [Rectangle](https://github.com/rxhanson/Rectangle)
 - [Redshift Scheduler](https://github.com/spantaleev/redshift-scheduler)
 - [Redshift](http://jonls.dk/redshift/)
 - [Rhythmbox](https://wiki.gnome.org/Apps/Rhythmbox)

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [R](http://www.r-project.org/)
 - [Rails](http://rubyonrails.org/)
 - [Ranger](https://ranger.github.io/)
-- [Rectangle](https://github.com/rxhanson/Rectangle)
+- [Rectangle](https://rectangleapp.com/)
 - [Redshift Scheduler](https://github.com/spantaleev/redshift-scheduler)
 - [Redshift](http://jonls.dk/redshift/)
 - [Rhythmbox](https://wiki.gnome.org/Apps/Rhythmbox)

--- a/mackup/applications/Rectangle.cfg
+++ b/mackup/applications/Rectangle.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Rectangle
+
+[configuration_files]
+Library/Preferences/com.knollsoft.Rectangle.plist


### PR DESCRIPTION
As per https://github.com/rxhanson/Rectangle/issues/25, Rectangle stores config at `~/Library/Preferences/com.knollsoft.Rectangle.plist`.

(fixes https://github.com/lra/mackup/issues/1481)