### PR TITLE
Improve support for AWS CLI, only sync config and exclude credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 
+- Improve support for AWS CLI, only sync config and exclude credentials (via @halilim)
 - Added support for Bat (via @joshmedeski)
 
 ## Mackup 0.8.27

--- a/mackup/applications/aws.cfg
+++ b/mackup/applications/aws.cfg
@@ -2,4 +2,4 @@
 name = AWS CLI
 
 [configuration_files]
-.aws
+.aws/config


### PR DESCRIPTION
AWS CLI [stores](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where) config in `~/.aws/config` and credentials in `~/.aws/credentials`.

Workaround until this is merged:

```ini
; ~/.mackup.cfg
[applications_to_ignore]
aws
```

```ini
; ~/.mackup/my-files.cfg
[configuration_files]
.aws/config
```

```bash
rm ~/.aws
mv  ~/Library/Mobile\ Documents/com\~apple\~CloudDocs/Mackup/.aws ~
mackup backup
```

And then please consider rotating AWS keys that are stored in `~/.aws/credentials`, depending on your Mackup storage and security requirements.