### PR TITLE
Add global git attributes

### DIFF
--- a/mackup/applications/git.cfg
+++ b/mackup/applications/git.cfg
@@ -7,3 +7,4 @@ name = Git
 [xdg_configuration_files]
 git/config
 git/ignore
+git/attributes


### PR DESCRIPTION
> Attributes that should affect all repositories for a single user should be placed in a file specified by the core.attributesFile configuration option (see git-config[1]). Its default value is **$XDG_CONFIG_HOME/git/attributes**. If $XDG_CONFIG_HOME is either not set or empty, $HOME/.config/git/attributes is used instead.

[Source](https://git-scm.com/docs/gitattributes#_description)