### PR TITLE
add support for zsh aliases file

### DIFF
--- a/mackup/applications/zsh_aliases.cfg
+++ b/mackup/applications/zsh_aliases.cfg
@@ -1,0 +1,5 @@
+[application]
+name = zsh_aliases
+
+[configuration_files]
+.zsh_aliases


### PR DESCRIPTION
adding support for .zsh_aliases file which is commonly used for defining additional aliases along with zsh.