### PR TITLE
update support for RStudio to handle JSON conf file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## WIP
 
 - Added support for Bat (via @joshmedeski)
+- Updated support for RStudio, config stored in JSON as of v1.3.776 (via @petrbouchal)
 
 ## Mackup 0.8.27
 

--- a/mackup/applications/rstudio.cfg
+++ b/mackup/applications/rstudio.cfg
@@ -4,3 +4,4 @@ name = RStudio
 [configuration_files]
 .rstudio-desktop
 Library/Preferences/org.rstudio.RStudio.plist
+.config/rstudio

--- a/mackup/applications/rstudio.cfg
+++ b/mackup/applications/rstudio.cfg
@@ -4,4 +4,6 @@ name = RStudio
 [configuration_files]
 .rstudio-desktop
 Library/Preferences/org.rstudio.RStudio.plist
-.config/rstudio
+
+[xdg_configuration_files]
+rstudio


### PR DESCRIPTION
The latest version of RStudio [stores its conf in a JSON](https://docs.rstudio.com/ide/desktop-pro/latest/settings.html).

This PR addresses this change and also includes other config files in the backup.