### PR TITLE
Allow mackup to be run as root with explicit flag

### DIFF
--- a/mackup/mackup.py
+++ b/mackup/mackup.py
@@ -28,11 +28,12 @@ class Mackup(object):
 
     def check_for_usable_environment(self):
         """Check if the current env is usable and has everything's required."""
-        # Do not let the user run Mackup as root
-        if os.geteuid() == 0:
+        # Allow only explicit superuser usage
+        if os.geteuid() == 0 and not utils.CAN_RUN_AS_ROOT:
             utils.error(
-                "Running Mackup as a superuser is useless and"
-                " dangerous. Don't do it!"
+                "Running Mackup as superuser can be dangerous."
+                " Don't do it unless you know what you're doing!"
+                " Run mackup --help for guidance."
             )
 
         # Do we have a folder to put the Mackup folder ?

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -15,6 +15,7 @@ Usage:
 Options:
   -h --help     Show this screen.
   -f --force    Force every question asked to be answered with "Yes".
+  -r --root     Allow mackup to be run as superuser.
   -n --dry-run  Show steps without executing.
   -v --verbose  Show additional details.
   --version     Show version.
@@ -72,6 +73,10 @@ def main():
     # If we want to answer mackup with "yes" for each question
     if args["--force"]:
         utils.FORCE_YES = True
+
+    # Allow mackup to be run as root
+    if args["--root"]:
+        utils.CAN_RUN_AS_ROOT = True
 
     dry_run = args["--dry-run"]
 

--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -16,6 +16,9 @@ from . import constants
 # If True, the user wants to say "yes" to everything.
 FORCE_YES = False
 
+# Flag that control if mackup can be run as root
+CAN_RUN_AS_ROOT = False
+
 
 def confirm(question):
     """


### PR DESCRIPTION
Hi, this is the pull request that I mentioned in https://github.com/lra/mackup/issues/666

It adds new -r --root flag that allows to backup/restore and other operations to be run as root if anyone (like me) want and need it. 

Another issue that this also fixes is: https://github.com/lra/mackup/issues/1236