### PR TITLE
Added IntelliJ 2019.3 & 2020.1

### DIFF
--- a/mackup/applications/intellijidea.cfg
+++ b/mackup/applications/intellijidea.cfg
@@ -59,3 +59,8 @@ IdeaIC2019.2/config
 Library/Preferences/IntelliJIdea2019.2
 Library/Application Support/IntelliJIdea2019.2
 IntelliJIdea2019.2/config
+IdeaIC2019.3/config
+Library/Preferences/IntelliJIdea2019.3
+Library/Application Support/IntelliJIdea2019.3
+IntelliJIdea2019.3/config
+Library/Application Support/JetBrains/IntelliJIdea2020.1


### PR DESCRIPTION
The default configuration directory for 2020.1 (and up) has changed according to https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lra/mackup/1541)
<!-- Reviewable:end -->
