### PR TITLE
Update tmuxinator configration path with xdg support

### DIFF
--- a/mackup/applications/tmuxinator.cfg
+++ b/mackup/applications/tmuxinator.cfg
@@ -1,5 +1,5 @@
 [application]
 name = Tmuxinator
 
-[configuration_files]
-.tmuxinator
+[xdg_configuration_files]
+tmuxinator


### PR DESCRIPTION
https://github.com/tmuxinator/tmuxinator

tmuxinator now uses XDG configration path.