### PR TITLE
Add unified iStat Menus config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added support for TripMode (via @ttuygun)
 - Added support for Starship (via @callummr)
 - Added support for Joplin (via @geekrainy)
+- Added support for iStat Menus 6 and unified config files (via @lumaxis)
 - Added the `--root` command line option
 - Removed support for Sketch
 - Add support for PyCharm 2020.1 (via @ameyuuno)

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [IntelliJIDEA](http://www.jetbrains.com/idea/)
 - [IPython](http://ipython.org/)
 - [Irssi](http://www.irssi.org/)
-- [iStat Menus 5](https://bjango.com/mac/istatmenus/)
+- [iStat Menus](https://bjango.com/mac/istatmenus/)
 - [Itsycal](https://github.com/sfsam/Itsycal)
 - [iTerm2](https://www.iterm2.com/)
 - [iTermocil](https://github.com/TomAnthony/itermocil)

--- a/mackup/applications/istat-menus-5.cfg
+++ b/mackup/applications/istat-menus-5.cfg
@@ -1,6 +1,0 @@
-[application]
-name = iStat Menus
-
-[configuration_files]
-Library/Preferences/com.bjango.istatmenus.plist
-Library/Preferences/com.bjango.istatmenus5.extras.plist

--- a/mackup/applications/istat-menus.cfg
+++ b/mackup/applications/istat-menus.cfg
@@ -1,0 +1,8 @@
+[application]
+name = iStat Menus
+
+[configuration_files]
+Library/Preferences/com.bjango.istatmenus.plist
+Library/Preferences/com.bjango.istatmenus.status.plist
+Library/Preferences/com.bjango.istatmenus5.extras.plist
+Library/Preferences/com.bjango.istatmenus6.extras.plist


### PR DESCRIPTION
Closes #1343

Addressing [@lra's comment](https://github.com/lra/mackup/pull/1343#issuecomment-478653992) from the above mentioned PR, this adds a unified config for iStat Menus across multiple versions.

I simply removed `istat-menus-5` since I'm not sure what the best way to "merge" configs is 🤔Happy to revert that commit though since this would be a breaking change for people and I'm not sure that is desired.