### PR TITLE
Small changes related to Storage paragraph

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -11,14 +11,15 @@ vi ~/.mackup.cfg
 
 ## Storage
 
-### Dropbox
-
 You can specify the storage type Mackup will use to store your configuration
 files.
-For now you have 4 options: `dropbox`, `google_drive`, `copy` and `file_system`.
+For now you have 4 options: `dropbox`, `google_drive`, `icloud`, `copy` and `file_system`.
+
 If none is specified, Mackup will try to use the default: `dropbox`.
 With the `dropbox` storage engine, Mackup will automatically figure out your
 Dropbox folder.
+
+### Dropbox
 
 ```ini
 [storage]


### PR DESCRIPTION
Separate the `Dropbox` sub-section from the introduction paragraph of `Storage` section.
Also add `icloud` in list of available storage.