### PR TITLE
Add support for iStat Menus 6

### DIFF
--- a/mackup/applications/istat-menus-5.cfg
+++ b/mackup/applications/istat-menus-5.cfg
@@ -1,6 +1,0 @@
-[application]
-name = iStat Menus
-
-[configuration_files]
-Library/Preferences/com.bjango.istatmenus.plist
-Library/Preferences/com.bjango.istatmenus5.extras.plist

--- a/mackup/applications/istat-menus.cfg
+++ b/mackup/applications/istat-menus.cfg
@@ -1,0 +1,9 @@
+[application]
+name = iStat Menus (5 and 6)
+
+[configuration_files]
+Library/Preferences/com.bjango.istatmenus.plist
+Library/Preferences/com.bjango.istatmenus5.extras.plist
+Library/Preferences/com.bjango.istatmenus6.extras.plist
+Library/Preferences/com.bjango.istatmenusstatus.plist
+Library/Preferences/com.bjango.istatmenus.status.plist


### PR DESCRIPTION
I tried to maintains backwards-compatibility with iStat Menus 5, since IIRC version 6 was a paid upgrade and only works in newer versions of macOS. 

Let me know if putting these in two files is preferable

Fixes #1560
