### PR TITLE
Catch unsupported Options in Config-File and print a warning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for clashX (via @awkj)
 - Added support for Brave (via @cbenv)
 - Added support for Nushell (via @leesiongchan)
+- Updated support for Clipy (via @jclerc)
 
 ## Mackup 0.8.29
 

--- a/mackup/applications/clipy.cfg
+++ b/mackup/applications/clipy.cfg
@@ -2,5 +2,4 @@
 name = Clipy
 
 [configuration_files]
-Library/Application Support/Clipy
 Library/Preferences/com.clipy-app.Clipy.plist


### PR DESCRIPTION
# Description
Give the user a notice if there are unsupported applications, sections and or options in her mackup.cfg-file. Unsupported applications get removed to avoid KeyError while looking up the application's filepaths.

# Implementation
Config.__init__() runs new method warn_on_unsupported_section(). This scans each sections in self._parser.sections() and each option for each section in self._parser.options(section) whether it is supported by Mackup or not. Prints a warning to console output. To quickly detect typos it also displays the closest-matching supported option.

Always fixes "KeyError" if an unsupported application is accidentally added to "applications_to_sync".

# Example:
```
% cat ~/.mackup.cfg
# Set up Backup Storage Engine
[storage]
engine = file_system
path = GitHub
directory = ProgramSettings
# Unsupported Option for "storage"
director = Bla

# Application which should be synced
[applications_to_sync]
vim
terminal
atom
xcode
git
# Unsupported application
foo

# Unsupported section
[storages]

% mackup backup -n                                       
Warnig: Unsupported option 'director' for section ['storage']!
	Did you mean 'directory'?
Warnig: Application 'foo' is not yet supported by Mackup.
	You may add support for it. See https://github.com/lra/mackup/tree/master/doc#get-official-support-for-an-application for details.
Warnig: Unsupported section '[storages]' detected!
	Did you mean '[storage]'?
```