### PR TITLE
remove fish_variables

### DIFF
--- a/mackup/applications/fish.cfg
+++ b/mackup/applications/fish.cfg
@@ -4,6 +4,5 @@ name = Fish
 [xdg_configuration_files]
 fish/config.fish
 fish/conf.d
-fish/fish_variables
 fish/functions
 fish/completions


### PR DESCRIPTION
fish_variables is automatically generated by fish-shell and is not intended to be edited by a human. Thus, it should not be backed up.

https://fishshell.com/docs/current/index.html?highlight=fish_variable#variables-universal