### PR TITLE
Don't sync paste history from Clipy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added support for clashX (via @awkj)
 - Added support for Brave (via @cbenv)
 - Added support for Nushell (via @leesiongchan)
+- Updated support for Clipy (via @jclerc)
 
 ## Mackup 0.8.29
 

--- a/mackup/applications/clipy.cfg
+++ b/mackup/applications/clipy.cfg
@@ -2,5 +2,4 @@
 name = Clipy
 
 [configuration_files]
-Library/Application Support/Clipy
 Library/Preferences/com.clipy-app.Clipy.plist


### PR DESCRIPTION
For context, Clipy is a tool which keeps recent history of your clipboard. The issue here is that it stores each paste history (and thus clipboard content) in a data file which is synced due to current mackup configuration.

It shouldn't happen, as stated by the CONTRIBUTING guide, and this PR aims to fix that.
> Do not sync any file or folder that represents some state, like session data, cache, any file specific to the local workstation.
> Do not sync sensitive information, like clear passwords or private keys

Note that `Library/Application Support/Clipy` is only used for paste history, no other file/configuration is in this directory, so it's safe to remove it from sync.

Thanks!