### PR TITLE
Support WebStorm 2020 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated support for Clipy (via @jclerc)
 - Added support for aerc (via @Crocmagnon)
 - Added support for espanso (via @maxandersen)
+- Added support for WebStorm versions 2019.4, 2020.2, 2020.3, 2020.4 (via @bdcarr)
 
 ## Mackup 0.8.29
 

--- a/mackup/applications/webstorm.cfg
+++ b/mackup/applications/webstorm.cfg
@@ -35,10 +35,11 @@ Library/Application Support/WebStorm2019.2
 Library/Preferences/WebStorm2019.2
 Library/Application Support/WebStorm2019.3
 Library/Preferences/WebStorm2019.3
-Library/Application Support/WebStorm2020.1
-Library/Preferences/WebStorm2020.1
-Library/Application Support/WebStorm2020.2
-Library/Preferences/WebStorm2020.2
-Library/Application Support/WebStorm2020.3
-Library/Preferences/WebStorm2020.3
+Library/Application Support/WebStorm2019.3
+Library/Preferences/WebStorm2019.3
+Library/Application Support/WebStorm2019.4
+Library/Preferences/WebStorm2019.4
 Library/Application Support/JetBrains/WebStorm2020.1
+Library/Application Support/JetBrains/WebStorm2020.2
+Library/Application Support/JetBrains/WebStorm2020.3
+Library/Application Support/JetBrains/WebStorm2020.4


### PR DESCRIPTION
I added 2020.{1,2,3} before, but I assumed the directories would be in the same location as previous WebStorm versions. This was not correct. It looks like there's no longer a `~/Library/Preferences` folder for WebStorm either; it's all in the one folder now.

There was also a 2019.4 version so I added that in case anyone's using it, and added a speculative 2020.4 line in case they make one.