### PR TITLE
Add support for Mendeley Desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added support for aerc (via @Crocmagnon)
 - Added support for espanso (via @maxandersen)
 - Added support for WebStorm versions 2019.4, 2020.2, 2020.3, 2020.4 (via @bdcarr)
+- Added support for Mendeley Desktop (via @aiotter)
 
 ## Mackup 0.8.29
 

--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [MATLAB](http://www.mathworks.com/products/matlab/)
 - [Maven](http://maven.apache.org)
 - [Max](http://sbooth.org/Max/)
+- [Mendeley Desktop](https://www.mendeley.com)
 - [MenuMeters](http://www.ragingmenace.com/software/menumeters/)
 - [Mercurial](https://www.mercurial-scm.org/)
 - [MercuryMover](http://www.heliumfoot.com/mercurymover/)

--- a/mackup/applications/mendeley.cfg
+++ b/mackup/applications/mendeley.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Mendelay Desktop
+
+[configuration_files]
+Library/Application Support/Mendeley Desktop


### PR DESCRIPTION
Add support for Mendeley Desktop, the free paper management application.
Tested by removing `Library/Application Support/Mendeley Desktop` and `Library/Application Support/Mendeley Ltd./Mendeley Desktop` before reinstalling it to execute `mackup restore`. Worked fine.