### PR TITLE
repair JetBrains WebStorm `DuplicateOptionError`

### DIFF
--- a/mackup/applications/webstorm.cfg
+++ b/mackup/applications/webstorm.cfg
@@ -35,8 +35,6 @@ Library/Application Support/WebStorm2019.2
 Library/Preferences/WebStorm2019.2
 Library/Application Support/WebStorm2019.3
 Library/Preferences/WebStorm2019.3
-Library/Application Support/WebStorm2019.3
-Library/Preferences/WebStorm2019.3
 Library/Application Support/WebStorm2019.4
 Library/Preferences/WebStorm2019.4
 Library/Application Support/JetBrains/WebStorm2020.1


### PR DESCRIPTION
error generated:
```
    raise DuplicateOptionError(sectname, optname,
configparser.DuplicateOptionError: While reading from '/usr/local/Cellar/mackup/HEAD-c03c2a2/libexec/lib/python3.8/site-packages/mackup/applications/webstorm.cfg' [line 38]: option 'Library/Application Support/WebStorm2019.3' in section 'configuration_files' already exists
```
 

keep one pair of the two duplicated lines that break functionality:
https://github.com/lra/mackup/blob/c03c2a2efa54ee964216d4811c8143182a0329ec/mackup/applications/webstorm.cfg#L36-L39

 
error’s first appearance:
    [https://github.com/lra/mackup/commit/901eab6](https://github.com/lra/mackup/commit/901eab685ed44fe3da42ad0a49ada2ba562244a1#diff-4eda02476608891c73a4e51f70f17903R36-R39)