### PR TITLE
repair `.cfg` file reference to Powerlevel10k

### DIFF
--- a/mackup/applications/p10k.cfg
+++ b/mackup/applications/p10k.cfg
@@ -1,5 +1,5 @@
 [application]
-name = p10k
+name = Powerlevel10k
 
 [configuration_files]
 .p10k.zsh


### PR DESCRIPTION
keep the application’s full name as in other `.cfg` files (added in #1636)