### PR TITLE
Add Hidden Bar for Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## WIP
 
+- Added support for Hidden Bar (via @tddschn)
 - Added support for SpaceVim (via @ionlights)
 - Added support for clashX (via @awkj)
 - Added support for Brave (via @cbenv)

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Heroku](https://www.heroku.com/)
 - [HexChat](https://hexchat.github.io/)
 - [Hexels](http://hexraystudios.com/hexels/)
+- [Hidden Bar](https://github.com/dwarvesf/hidden/)
 - [Homebridge](https://github.com/nfarina/homebridge)
 - [Homebrew](https://brew.sh)
 - [Houdini](http://uglyapps.co.uk/houdini/)

--- a/mackup/applications/hiddenbar.cfg
+++ b/mackup/applications/hiddenbar.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Hidden Bar
+
+[configuration_files]
+Library/Containers/com.dwarvesv.minimalbar/Container.plist


### PR DESCRIPTION
I tested it on macOS Catalina 10.15.7. After copying the config file (a plist) to its original location and restarting Hidden Bar.app, I was able to restore the original config.