### PR TITLE
Add support for rubiTrack 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Added support for Netlify (via @pgilad)
 - Added support for K9s (via @tareksamni)
 - Added support for Powerlevel10k (via @tareksamni)
+- Added support for rubiTrack 5 (via @otherguy)
+
 
 ## Mackup 0.8.29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 - Added support for Powerlevel10k (via @tareksamni)
 - Added support for rubiTrack 5 (via @otherguy)
 
-
 ## Mackup 0.8.29
 
 - Added support for waybar (via @mk-atlassian)

--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Royal TSX](http://www.royaltsx.com/ts/osx/features)
 - [RStudio](https://www.rstudio.com/)
 - [rTorrent](http://libtorrent.rakshasa.no/)
+- [rubiTrack 5](https://www.rubitrack.com)
 - [Rubocop](https://github.com/bbatsov/rubocop)
 - [Ruby Version Manager](https://rvm.io/)
 - [Ruby Version](https://gist.github.com/fnichol/1912050)

--- a/mackup/applications/rubitrack5.cfg
+++ b/mackup/applications/rubitrack5.cfg
@@ -1,0 +1,5 @@
+[application]
+name = RubiTrack5
+
+[configuration_files]
+Library/Preferences/com.shiftoption.rubitrack5.pro.plist

--- a/mackup/applications/rubitrack5.cfg
+++ b/mackup/applications/rubitrack5.cfg
@@ -1,5 +1,5 @@
 [application]
-name = RubiTrack5
+name = rubiTrack 5
 
 [configuration_files]
 Library/Preferences/com.shiftoption.rubitrack5.pro.plist


### PR DESCRIPTION
Add support for [rubiTrack 5](https://www.rubitrack.com), a tool _"to track and improve performance for runners, cyclists, triathletes and enthusiasts in any sport"_.
