### PR TITLE
fix: aria2 supports XDG_CONFIG_HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added support for Netlify (via @pgilad)
 - Added support for K9s (via @tareksamni)
 - Added support for Powerlevel10k (via @tareksamni)
+- Updated support for aria2 (via @hongqn)
 
 ## Mackup 0.8.29
 

--- a/mackup/applications/aria2c.cfg
+++ b/mackup/applications/aria2c.cfg
@@ -3,3 +3,6 @@ name = aria2c
 
 [configuration_files]
 .aria2
+
+[xdg_configuration_files]
+aria2


### PR DESCRIPTION
Quote from [aria2 documentation](https://aria2.github.io/manual/en/html/aria2c.html#aria2-conf):

> By default, aria2 checks whether the legacy path
> `$HOME/.aria2/aria2.conf` is present, otherwise it parses
> `$XDG_CONFIG_HOME/aria2/aria2.conf` as its configuration file.
