### PR TITLE
Add support for rubiTrack 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed support for poetry (via @ameyuuno)
 - Added support for npm package npmrc (via @jdvivar)
+- Added support for rubiTrack 5 (via @otherguy)
 
 ## Mackup 0.8.32
 

--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Royal TSX](http://www.royaltsx.com/ts/osx/features)
 - [RStudio](https://www.rstudio.com/)
 - [rTorrent](http://libtorrent.rakshasa.no/)
+- [rubiTrack 5](https://www.rubitrack.com)
 - [Rubocop](https://github.com/bbatsov/rubocop)
 - [Ruby Version Manager](https://rvm.io/)
 - [Ruby Version](https://gist.github.com/fnichol/1912050)

--- a/mackup/applications/rubitrack5.cfg
+++ b/mackup/applications/rubitrack5.cfg
@@ -1,0 +1,5 @@
+[application]
+name = rubiTrack 5
+
+[configuration_files]
+Library/Preferences/com.shiftoption.rubitrack5.pro.plist


### PR DESCRIPTION
Add support for [rubiTrack 5](https://www.rubitrack.com), a tool _"to track and improve performance for runners, cyclists, triathletes and enthusiasts in any sport"_.
