### PR TITLE
Improve the error message when no storage is found

### DIFF
--- a/mackup/constants.py
+++ b/mackup/constants.py
@@ -27,3 +27,16 @@ ENGINE_DROPBOX = "dropbox"
 ENGINE_FS = "file_system"
 ENGINE_GDRIVE = "google_drive"
 ENGINE_ICLOUD = "icloud"
+
+DOCUMENTATION_URL = "https://github.com/lra/mackup/blob/master/doc/README.md"
+
+# Error message displayed when mackup can't find the storage specified
+# in the config (or the default one).
+ERROR_UNABLE_TO_FIND_STORAGE = (
+    "Unable to find your {provider} =(\n"
+    "If this is the first time you use %s, you may want "
+    "to use another provider.\n"
+    "Take a look at the documentation [1] to know more about "
+    "how to configure mackup.\n\n"
+    "[1]: %s" % (MACKUP_APP_NAME, DOCUMENTATION_URL)
+)

--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -205,7 +205,7 @@ def get_dropbox_folder_location():
         with open(host_db_path, "r") as f_hostdb:
             data = f_hostdb.read().split()
     except IOError:
-        error("Unable to find your Dropbox install =(")
+        error(constants.ERROR_UNABLE_TO_FIND_STORAGE.format(provider="Dropbox install"))
     dropbox_home = base64.b64decode(data[1]).decode()
 
     return dropbox_home
@@ -244,7 +244,11 @@ def get_google_drive_folder_location():
             con.close()
 
     if not googledrive_home:
-        error("Unable to find your Google Drive install =(")
+        error(
+            constants.ERROR_UNABLE_TO_FIND_STORAGE.format(
+                provider="Google Drive install"
+            )
+        )
 
     return googledrive_home
 
@@ -272,7 +276,7 @@ def get_copy_folder_location():
             cur.close()
 
     if not copy_home:
-        error("Unable to find your Copy install =(")
+        error(constants.ERROR_UNABLE_TO_FIND_STORAGE.format(provider="Copy install"))
 
     return copy_home
 
@@ -289,7 +293,7 @@ def get_icloud_folder_location():
     icloud_home = os.path.expanduser(yosemite_icloud_path)
 
     if not os.path.isdir(icloud_home):
-        error("Unable to find your iCloud Drive =(")
+        error(constants.ERROR_UNABLE_TO_FIND_STORAGE.format(provider="iCloud Drive"))
 
     return str(icloud_home)
 


### PR DESCRIPTION
This relates to issue #1621. It improves the error message when the storage is not found by pointing the user to the docs.

This is useful for first-time users as they could otherwise just understand that only Dropbox is supported.

I don't know if it closes the issue but at least it improves the situation described.