### PR TITLE
Fix typo in finicky.cfg

### DIFF
--- a/mackup/applications/finicky.cfg
+++ b/mackup/applications/finicky.cfg
@@ -1,5 +1,5 @@
 [application]
-name = fincky
+name = finicky
 
 [configuration_files]
 .finicky.js


### PR DESCRIPTION
`finicky.cfg` contains a typo in application name.