### PR TITLE
Add .default-npm-packages to asdf

### DIFF
--- a/mackup/applications/asdf.cfg
+++ b/mackup/applications/asdf.cfg
@@ -5,3 +5,4 @@ name = asdf
 .asdfrc
 .tool-versions
 .default-gems
+.default-npm-packages


### PR DESCRIPTION
Similar to #1290, this adds `.default-npm-packages` to asdf, which is the asdf-nodejs equivalent to `.default-gems` (see https://github.com/asdf-vm/asdf-nodejs#default-npm-packages).