### PR TITLE
Include custom key bindings for MailMate

### DIFF
--- a/mackup/applications/mailmate.cfg
+++ b/mackup/applications/mailmate.cfg
@@ -10,3 +10,4 @@ Library/Application Support/Mailmate/Signatures.plist
 Library/Application Support/Mailmate/Sources.plist
 Library/Application Support/Mailmate/Submission.plist
 Library/Application Support/Mailmate/Tags.plist
+Library/Application Support/Mailmate/Resources/KeyBindings


### PR DESCRIPTION
Custom Keybindings can be created by editing .plist files located in the 
folder Library/Application Support/Mailmate/Resources/KeyBindings.
These should sync as well. Documentation of this feature is here:
https://manual.mailmate-app.com/custom_key_bindings