### PR TITLE
Remove-discontinued-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ in it stay put, so that any other computer also running Mackup is unaffected.
 
 - [Dropbox](https://www.dropbox.com/)
 - [Google Drive](https://drive.google.com/)
-- [Copy](https://www.copy.com/)
 - [iCloud](http://www.apple.com/icloud/)
 - Anything able to sync a folder (e.g. [Git](http://git-scm.com/))
 


### PR DESCRIPTION
Copy was discontinued on May 1, 2016. So I had to remove it from Supported storages list.