### PR TITLE
Update neovim to support init.lua

### DIFF
--- a/mackup/applications/neovim.cfg
+++ b/mackup/applications/neovim.cfg
@@ -7,3 +7,4 @@ name = neovim
 
 [xdg_configuration_files]
 nvim/init.vim
+nvim/init.lua

--- a/mackup/applications/neovim.cfg
+++ b/mackup/applications/neovim.cfg
@@ -8,3 +8,4 @@ name = neovim
 [xdg_configuration_files]
 nvim/init.vim
 nvim/init.lua
+nvim/lua


### PR DESCRIPTION
Neovim from v0.5 onwards will support an init.lua config file (as per this [commit](https://github.com/neovim/neovim/commit/72c22862dc2199462aef0d450a49d29a9d0680b9)). This pull request adds support for this.