### PR TITLE
Add support for universal-ctags

### DIFF
--- a/mackup/applications/ctags.cfg
+++ b/mackup/applications/ctags.cfg
@@ -3,3 +3,4 @@ name = Ctags
 
 [configuration_files]
 .ctags
+.ctags.d


### PR DESCRIPTION
According https://github.com/universal-ctags/ctags/pull/1519/files, universal-ctags use ~/.ctags.d/*.ctags instead ~/.ctags
I think this is an enhance feature.