### PR TITLE
Add support for Sublime Text 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added support for Qv2ray (via @kidonng)
 - Added support for Neofetch (via @kidonng)
 - Added support for PsySH (via @nesk)
+- Added support for Sublime Text 4 (via @TCattd)
 
 ## Mackup 0.8.32
 

--- a/mackup/applications/sublime-text.cfg
+++ b/mackup/applications/sublime-text.cfg
@@ -1,0 +1,9 @@
+[application]
+name = Sublime Text
+
+[configuration_files]
+# Based on https://packagecontrol.io/docs/syncing
+Library/Application Support/Sublime Text/Packages/User
+
+[xdg_configuration_files]
+sublime-text/Packages/User


### PR DESCRIPTION
Add support for Sublime Text 4. Or Sublime Text. No number at the end.

Settings folder now has no version number, and un-official announcement (Discord https://tppr.me/gkDTU ) says that Sublime Text will drop version numbers entirely (will keep his internal build numbers, of course).

Builds from 4000 branch (available in official Sublime's Discord) use this new path without number on it to save settings.
