### PR TITLE
Add support for AltTab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added support for Neofetch (via @kidonng)
 - Added support for PsySH (via @nesk)
 - Added support for Sublime Text 4 (via @TCattd)
+- Added support for AltTab (via @aiotter)
 
 ## Mackup 0.8.32
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [aerc](https://aerc-mail.org/)
 - [Airmail](http://airmailapp.com/)
 - [Alacritty](https://github.com/jwilm/alacritty)
+- [AltTab](https://alt-tab-macos.netlify.app/)
 - [Amethyst](https://ianyh.com/amethyst/)
 - [Ancient Domains of Mystery](http://www.adom.de/home/index.html)
 - [Android Studio](https://developer.android.com/sdk/)

--- a/mackup/applications/alt-tab.cfg
+++ b/mackup/applications/alt-tab.cfg
@@ -1,0 +1,5 @@
+[application]
+name = AltTab
+
+[configuration_files]
+Library/Preferences/com.lwouis.alt-tab-macos.plist


### PR DESCRIPTION
Add support for [AltTab](https://alt-tab-macos.netlify.app/), Windows’s “alt-tab” app switcher for macOS.