### PR TITLE
Add support for .vim/bundle folder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Updated support for fasd (via @doubleloop)
 - Added support for Nova (via @guillaumealgis)
 - Added support for PicGo (via @SSBun)
+- Updated support for vim (via @iarchean)
 
 ## Mackup 0.8.33
 

--- a/mackup/applications/vim.cfg
+++ b/mackup/applications/vim.cfg
@@ -7,6 +7,7 @@ name = Vim
 .gvimrc.before
 .vim/autoload
 .vim/after
+.vim/bundle
 .vim/colors
 .vim/doc
 .vim/ftdetect


### PR DESCRIPTION
since my all vim plugins are placed on .vim/bundle folder, so add support for it.