### PR TITLE
Fixed k9s config location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added support for Nova (via @guillaumealgis)
 - Added support for PicGo (via @SSBun)
 - Added support for Planner (via @spawnedc)
+- Fixed support for k9s (via @gamussa)
 
 ## Mackup 0.8.33
 

--- a/mackup/applications/k9s.cfg
+++ b/mackup/applications/k9s.cfg
@@ -1,9 +1,6 @@
 [application]
 name = k9s
 
-[configuration_files]
-.k9s/config.yml
-
 [xdg_configuration_files]
 k9s/config.yml
 k9s/skin.yml

--- a/mackup/applications/k9s.cfg
+++ b/mackup/applications/k9s.cfg
@@ -2,4 +2,5 @@
 name = k9s
 
 [configuration_files]
-.k9s/config.yml
+Library/Preferences/k9s/config.yml
+Library/Preferences/k9s/skin.yml

--- a/mackup/applications/k9s.cfg
+++ b/mackup/applications/k9s.cfg
@@ -2,5 +2,8 @@
 name = k9s
 
 [configuration_files]
-Library/Preferences/k9s/config.yml
-Library/Preferences/k9s/skin.yml
+.k9s/config.yml
+
+[xdg_configuration_files]
+k9s/config.yml
+k9s/skin.yml


### PR DESCRIPTION
Background:
According to https://k9scli.io/topics/shell/ k9s uses $XDG_CONFIG_HOME environment variable to locate config files.
According to https://stackoverflow.com/questions/3373948/equivalents-of-xdg-config-home-and-xdg-data-home-on-mac-os-x $XDG_CONFIG_HOME is located at ~/Library/Preferences/

﻿### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced

### Improving the Mackup codebase

* [ ] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [ ] I have linted the code locally prior to submission
* [ ] I have written new tests as applicable
* [ ] I have added an explanation of what the changes do
