### PR TITLE
Fix code formatting and "Lint Python" GitHub Action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - run: pip install black
       - uses: actions/checkout@v2
-      - run: black --check --target-version py27 .
+      - run: black --check --target-version py310 .

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ release: clean
 	pipenv run twine upload dist/*
 
 black:
-	black --target-version py27 .
+	black --target-version py310 .

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -28,10 +28,10 @@ class TestConfig(unittest.TestCase):
         assert cfg.path == "/home/some_user/Dropbox"
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"Mackup"
+        assert cfg.directory == "Mackup"
 
         assert isinstance(cfg.fullpath, str)
-        assert cfg.fullpath == u"/home/some_user/Dropbox/Mackup"
+        assert cfg.fullpath == "/home/some_user/Dropbox/Mackup"
 
         assert cfg.apps_to_ignore == set()
         assert cfg.apps_to_sync == set()
@@ -43,13 +43,13 @@ class TestConfig(unittest.TestCase):
         assert cfg.engine == ENGINE_DROPBOX
 
         assert isinstance(cfg.path, str)
-        assert cfg.path == u"/home/some_user/Dropbox"
+        assert cfg.path == "/home/some_user/Dropbox"
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"Mackup"
+        assert cfg.directory == "Mackup"
 
         assert isinstance(cfg.fullpath, str)
-        assert cfg.fullpath == u"/home/some_user/Dropbox/Mackup"
+        assert cfg.fullpath == "/home/some_user/Dropbox/Mackup"
 
         assert cfg.apps_to_ignore == set()
         assert cfg.apps_to_sync == set()
@@ -61,13 +61,13 @@ class TestConfig(unittest.TestCase):
         assert cfg.engine == ENGINE_DROPBOX
 
         assert isinstance(cfg.path, str)
-        assert cfg.path == u"/home/some_user/Dropbox"
+        assert cfg.path == "/home/some_user/Dropbox"
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"some_weirld_name"
+        assert cfg.directory == "some_weirld_name"
 
         assert isinstance(cfg.fullpath, str)
-        assert cfg.fullpath == u"/home/some_user/Dropbox/some_weirld_name"
+        assert cfg.fullpath == "/home/some_user/Dropbox/some_weirld_name"
 
         assert cfg.apps_to_ignore == set()
         assert cfg.apps_to_sync == set()
@@ -79,13 +79,13 @@ class TestConfig(unittest.TestCase):
         assert cfg.engine == ENGINE_FS
 
         assert isinstance(cfg.path, str)
-        assert cfg.path == u"/some/absolute/folder"
+        assert cfg.path == "/some/absolute/folder"
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"custom_folder"
+        assert cfg.directory == "custom_folder"
 
         assert isinstance(cfg.fullpath, str)
-        assert cfg.fullpath == u"/some/absolute/folder/custom_folder"
+        assert cfg.fullpath == "/some/absolute/folder/custom_folder"
 
         assert cfg.apps_to_ignore == set(["subversion", "sequel-pro"])
         assert cfg.apps_to_sync == set()
@@ -98,15 +98,15 @@ class TestConfig(unittest.TestCase):
 
         assert isinstance(cfg.path, str)
         assert cfg.path.endswith(
-            os.path.join(os.environ[u"HOME"], u"some/relative/folder")
+            os.path.join(os.environ["HOME"], "some/relative/folder")
         )
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"Mackup"
+        assert cfg.directory == "Mackup"
 
         assert isinstance(cfg.fullpath, str)
         assert cfg.fullpath == os.path.join(
-            os.environ[u"HOME"], u"some/relative/folder", u"Mackup"
+            os.environ["HOME"], "some/relative/folder", "Mackup"
         )
 
         assert cfg.apps_to_ignore == set()
@@ -119,13 +119,13 @@ class TestConfig(unittest.TestCase):
         assert cfg.engine == ENGINE_GDRIVE
 
         assert isinstance(cfg.path, str)
-        assert cfg.path == u"/Users/whatever/Google Drive"
+        assert cfg.path == "/Users/whatever/Google Drive"
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"Mackup"
+        assert cfg.directory == "Mackup"
 
         assert isinstance(cfg.fullpath, str)
-        assert cfg.fullpath.endswith(u"/Google Drive/Mackup")
+        assert cfg.fullpath.endswith("/Google Drive/Mackup")
 
         assert cfg.apps_to_ignore == set(["subversion", "sequel-pro", "sabnzbd"])
         assert cfg.apps_to_sync == set(["sublime-text-3", "x11", "sabnzbd"])
@@ -137,13 +137,13 @@ class TestConfig(unittest.TestCase):
         assert cfg.engine == ENGINE_COPY
 
         assert isinstance(cfg.path, str)
-        assert cfg.path == u"/Users/someuser/Copy"
+        assert cfg.path == "/Users/someuser/Copy"
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"Mackup"
+        assert cfg.directory == "Mackup"
 
         assert isinstance(cfg.fullpath, str)
-        assert cfg.fullpath.endswith(u"/Copy/Mackup")
+        assert cfg.fullpath.endswith("/Copy/Mackup")
 
         assert cfg.apps_to_ignore == set(["subversion", "sequel-pro", "sabnzbd"])
         assert cfg.apps_to_sync == set(["sublime-text-3", "x11", "sabnzbd"])
@@ -160,10 +160,10 @@ class TestConfig(unittest.TestCase):
         )
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"Mackup"
+        assert cfg.directory == "Mackup"
 
         assert isinstance(cfg.fullpath, str)
-        assert cfg.fullpath.endswith(u"/com~apple~CloudDocs/Mackup")
+        assert cfg.fullpath.endswith("/com~apple~CloudDocs/Mackup")
 
         assert cfg.apps_to_ignore == set(["subversion", "sequel-pro", "sabnzbd"])
         assert cfg.apps_to_sync == set(["sublime-text-3", "x11", "sabnzbd"])
@@ -186,10 +186,10 @@ class TestConfig(unittest.TestCase):
         assert cfg.path == "/home/some_user/Dropbox"
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"Mackup"
+        assert cfg.directory == "Mackup"
 
         assert isinstance(cfg.fullpath, str)
-        assert cfg.fullpath == u"/home/some_user/Dropbox/Mackup"
+        assert cfg.fullpath == "/home/some_user/Dropbox/Mackup"
 
         assert cfg.apps_to_ignore == set(["subversion", "sequel-pro", "sabnzbd"])
         assert cfg.apps_to_sync == set()
@@ -201,13 +201,13 @@ class TestConfig(unittest.TestCase):
         assert cfg.engine == ENGINE_DROPBOX
 
         assert isinstance(cfg.path, str)
-        assert cfg.path == u"/home/some_user/Dropbox"
+        assert cfg.path == "/home/some_user/Dropbox"
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"Mackup"
+        assert cfg.directory == "Mackup"
 
         assert isinstance(cfg.fullpath, str)
-        assert cfg.fullpath == u"/home/some_user/Dropbox/Mackup"
+        assert cfg.fullpath == "/home/some_user/Dropbox/Mackup"
 
         assert cfg.apps_to_ignore == set()
         assert cfg.apps_to_sync == set(["sabnzbd", "sublime-text-3", "x11"])
@@ -219,13 +219,13 @@ class TestConfig(unittest.TestCase):
         assert cfg.engine == ENGINE_DROPBOX
 
         assert isinstance(cfg.path, str)
-        assert cfg.path == u"/home/some_user/Dropbox"
+        assert cfg.path == "/home/some_user/Dropbox"
 
         assert isinstance(cfg.directory, str)
-        assert cfg.directory == u"Mackup"
+        assert cfg.directory == "Mackup"
 
         assert isinstance(cfg.fullpath, str)
-        assert cfg.fullpath == u"/home/some_user/Dropbox/Mackup"
+        assert cfg.fullpath == "/home/some_user/Dropbox/Mackup"
 
         assert cfg.apps_to_ignore == set(["subversion", "sequel-pro", "sabnzbd"])
         assert cfg.apps_to_sync == set(["sabnzbd", "sublime-text-3", "x11", "vim"])


### PR DESCRIPTION
This pull request updates the `black` target version to Python 3.10 as Python 2 support was dropped in https://github.com/psf/black/releases/tag/22.1.0. This should also fix the GitHub Action that is failing.