### PR TITLE
feat: trim inline and line comments out of config

### DIFF
--- a/mackup/config.py
+++ b/mackup/config.py
@@ -20,6 +20,7 @@ from .utils import (
     get_copy_folder_location,
     get_google_drive_folder_location,
     get_icloud_folder_location,
+    get_options
 )
 
 try:
@@ -256,7 +257,7 @@ class Config(object):
         # Is the "[applications_to_ignore]" in the cfg file?
         section_title = "applications_to_ignore"
         if self._parser.has_section(section_title):
-            apps_to_ignore = set(self._parser.options(section_title))
+            apps_to_ignore = get_options(self, section_title)
 
         return apps_to_ignore
 
@@ -273,7 +274,7 @@ class Config(object):
         # Is the "[applications_to_sync]" section in the cfg file?
         section_title = "applications_to_sync"
         if self._parser.has_section(section_title):
-            apps_to_sync = set(self._parser.options(section_title))
+            apps_to_sync = get_options(self, section_title)
 
         return apps_to_sync
 

--- a/mackup/config.py
+++ b/mackup/config.py
@@ -20,7 +20,7 @@ from .utils import (
     get_copy_folder_location,
     get_google_drive_folder_location,
     get_icloud_folder_location,
-    get_options
+    get_options,
 )
 
 try:

--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -395,3 +395,27 @@ def can_file_be_synced_on_current_platform(path):
             can_be_synced = False
 
     return can_be_synced
+
+def get_options(self, section_title):
+    """
+    Return a list of option names for the given section name.
+
+    Removes inline comments and ignores comment lines.
+
+    Args:
+        (str): Name of the section to get the options for. 
+
+    Returns:
+        (set): options without comments
+    """
+    options = set(self._parser.options(section_title))
+    trimmed_options = set()
+    for line in options:
+        line = line.split('#',1)[0].strip()
+        if not line:
+            continue
+        else:
+            trimmed_options.add(line)
+    print(trimmed_options)
+    return trimmed_options
+

--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -396,6 +396,7 @@ def can_file_be_synced_on_current_platform(path):
 
     return can_be_synced
 
+
 def get_options(self, section_title):
     """
     Return a list of option names for the given section name.
@@ -403,7 +404,7 @@ def get_options(self, section_title):
     Removes inline comments and ignores comment lines.
 
     Args:
-        (str): Name of the section to get the options for. 
+        (str): Name of the section to get the options for.
 
     Returns:
         (set): options without comments
@@ -411,11 +412,10 @@ def get_options(self, section_title):
     options = set(self._parser.options(section_title))
     trimmed_options = set()
     for line in options:
-        line = line.split('#',1)[0].strip()
+        line = line.split("#", 1)[0].strip()
         if not line:
             continue
         else:
             trimmed_options.add(line)
     print(trimmed_options)
     return trimmed_options
-

--- a/tests/fixtures/mackup-apps_to_ignore.cfg
+++ b/tests/fixtures/mackup-apps_to_ignore.cfg
@@ -1,4 +1,5 @@
 [applications_to_ignore]
 subversion
-sequel-pro
+sequel-pro # inline comment
+# comment line
 sabnzbd

--- a/tests/fixtures/mackup-apps_to_ignore_and_sync.cfg
+++ b/tests/fixtures/mackup-apps_to_ignore_and_sync.cfg
@@ -1,6 +1,7 @@
 [applications_to_sync]
-sabnzbd
+sabnzbd # inline comment
 sublime-text-3
+# line comment
 x11
 vim
 


### PR DESCRIPTION
Closes https://github.com/lra/mackup/issues/1832

Add support for inline comments or lined comments inside the config file.

- Abstracted get options function to trim inline comments and remove line comments from set
- Updated parsing functions with abstracted function
- Added inline comments and line comments to test config files (tests are passing!)

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Improving the Mackup codebase

* [x] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [x] I have linted the code locally prior to submission
* [x] I have written new tests as applicable
* [x] I have added an explanation of what the changes do
