### PR TITLE
feat: configure parser to support inline comments

### DIFF
--- a/mackup/config.py
+++ b/mackup/config.py
@@ -147,7 +147,7 @@ class Config(object):
         if not filename:
             filename = MACKUP_CONFIG_FILE
 
-        parser = configparser.SafeConfigParser(allow_no_value=True)
+        parser = configparser.SafeConfigParser(allow_no_value=True, inline_comment_prefixes=(';','#'))
         parser.read(os.path.join(os.path.join(os.environ["HOME"], filename)))
 
         return parser

--- a/mackup/config.py
+++ b/mackup/config.py
@@ -147,7 +147,9 @@ class Config(object):
         if not filename:
             filename = MACKUP_CONFIG_FILE
 
-        parser = configparser.SafeConfigParser(allow_no_value=True, inline_comment_prefixes=(';','#'))
+        parser = configparser.SafeConfigParser(
+            allow_no_value=True, inline_comment_prefixes=(";", "#")
+        )
         parser.read(os.path.join(os.path.join(os.environ["HOME"], filename)))
 
         return parser

--- a/tests/fixtures/mackup-apps_to_ignore.cfg
+++ b/tests/fixtures/mackup-apps_to_ignore.cfg
@@ -1,4 +1,4 @@
 [applications_to_ignore]
-subversion
-sequel-pro
+subversion ; inline comment
+sequel-pro # inline comment
 sabnzbd


### PR DESCRIPTION
Resolves https://github.com/lra/mackup/issues/1832

Work started at https://github.com/lra/mackup/pull/1833 but we decided it was best to use the built-in functionality.

This PR configures the parser to support inline comments (prefixed with either "#" or ";").

---

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Improving the Mackup codebase

* [x] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [x] I have linted the code locally prior to submission
* [x] I have written new tests as applicable
* [x] I have added an explanation of what the changes do
