### PR TITLE
Added support for btop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated support for iTerm2 (via @michielgerritsen)
 - Added support for NSLogger (via @lavareX)
 - Added support for Fork (via @lavareX)
+- Added support for Btop (via @Mersid)
 
 ## Mackup 0.8.34
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Boxer](http://boxerapp.com)
 - [Brackets](http://brackets.io/)
 - [Brave](https://brave.com/)
+- [Btop](https://github.com/aristocratos/btop)
 - [Bump](https://github.com/fabiospampinato/bump)
 - [Bundler](http://bundler.io)
 - [Byobu](http://byobu.co/)

--- a/mackup/applications/btop.cfg
+++ b/mackup/applications/btop.cfg
@@ -1,0 +1,5 @@
+[application]
+name = btop
+
+[xdg_configuration_files]
+btop


### PR DESCRIPTION
Adds support for [btop](https://github.com/aristocratos/btop)

### All submissions

* [X] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [X] This PR is only for one application
* [X] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [X] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [X] Syncing does not break the application
* [X] Syncing does not compete with any syncing functionality internal to the application
* [X] The configuration syncs the minimal set of data
* [X] No file specific to the local workstation is synced
* [X] No sensitive data is synced

### Improving the Mackup codebase

* [ ] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [ ] I have linted the code locally prior to submission
* [ ] I have written new tests as applicable
* [ ] I have added an explanation of what the changes do
