### PR TITLE
Update Nushell config paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for Fork (via @lavareX)
 - Updated support for Proxymann Setapp version (via @JanC)
 - Added support for Btop (via @Mersid)
+- Updated support for Nushell (via @maradude)
 
 ## Mackup 0.8.34
 

--- a/mackup/applications/nushell.cfg
+++ b/mackup/applications/nushell.cfg
@@ -1,6 +1,10 @@
 [application]
 name = Nushell
 
+[configuration_files]
+Library/Application Support/nushell/env.nu
+Library/Application Support/nushell/config.nu
+
 [xdg_configuration_files]
 nushell/config.nu
 nushell/env.nu

--- a/mackup/applications/nushell.cfg
+++ b/mackup/applications/nushell.cfg
@@ -2,4 +2,5 @@
 name = Nushell
 
 [xdg_configuration_files]
-nu/config.toml
+nushell/config.nu
+nushell/env.nu


### PR DESCRIPTION
## Summary

Added missing Nushell macOS paths and updated the synced config files to match the ones in the latest release version (at the time of writing 0.66). 

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced