### PR TITLE
Add support for VSCode Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Updated support for Proxymann Setapp version (via @JanC)
 - Added support for Btop (via @Mersid)
 - Updated support for Nushell (via @maradude)
+- Added support for VSCode Extensions (via @nyshk97)
 
 ## Mackup 0.8.34
 

--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Vimperator](http://www.vimperator.org/vimperator)
 - [Viscosity](http://www.sparklabs.com/viscosity/)
 - [Visual Studio Code](https://code.visualstudio.com/)
+- [Visual Studio Code - Extensions](https://code.visualstudio.com/)
 - [Visual Studio Code - Insiders](https://code.visualstudio.com/insiders)
 - [Visual Studio Code - OSS](https://github.com/Microsoft/vscode)
 - [VSCodium](https://vscodium.com/)

--- a/mackup/applications/vscode-extensions.cfg
+++ b/mackup/applications/vscode-extensions.cfg
@@ -1,0 +1,5 @@
+[application]
+name = name = Visual Studio Code Extensions
+
+[configuration_files]
+.vscode/extensions


### PR DESCRIPTION
I have read discussions below.
https://github.com/lra/mackup/pull/1510
https://github.com/lra/mackup/pull/1170

Still I think it's useful to sync VSCode extensions, and I guess not a few people think the same.

Considering the number of VSCode users, it's better to sync VSCode extensions out of the box and **disable only the extension part** if you want, than force to investigate where extensions settings are and create `cfg` file from scratch.

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [ ] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced
