### PR TITLE
fix: add back compat to espanso app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added support for Btop (via @Mersid)
 - Updated support for Nushell (via @maradude)
 - Updated support for CleanShot (via @timfee)
+- Added backwards-compatibility support for Espanso (via @joshmedeski)
 
 ## Mackup 0.8.34
 

--- a/mackup/applications/espanso.cfg
+++ b/mackup/applications/espanso.cfg
@@ -2,6 +2,7 @@
 name = espanso
 
 [configuration_files]
+Library/Preferences/espanso
 Library/Application Support/espanso
 
 [xdg_configuration_files]


### PR DESCRIPTION
Closes https://github.com/lra/mackup/issues/1845

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced

### Reason for change

Adding backward compatibility for Espanso for anyone who might be using <0.7.3

https://espanso.org/docs/get-started/#configuration

> NOTE: when migrating from the previous 0.7.3 version, the configuration directory will be located in $HOME/Library/Preferences/espanso for compatibility purposes.
