### PR TITLE
add Installed Packages for Sublime Text 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added support for PrusaSlicer (via @visika)
 - Added support for Logseq (via @visika)
 - Added support for SwitchHosts (via @zxjlm)
+- Fixed support for Sublime Text (via @zirawell)
 
 ## Mackup 0.8.36
 

--- a/mackup/applications/sublime-text.cfg
+++ b/mackup/applications/sublime-text.cfg
@@ -4,6 +4,7 @@ name = Sublime Text
 [configuration_files]
 # Based on https://packagecontrol.io/docs/syncing
 Library/Application Support/Sublime Text/Packages/User
+Library/Application Support/Sublime Text/Installed Packages
 
 [xdg_configuration_files]
 sublime-text/Packages/User


### PR DESCRIPTION
I have encountered a problem when I use `mackup restore` for Sublime Text4
I have used `command shift P` for `Package Controller:Install Package` to install the theme `ayu` and run `mackup backup` on my first computer.
Then I use `mackup restore` to restore my config on another computer.
It will appear to encounter a problem about the theme `ayu`. 
I found that the theme 'ayu' is installed in another path and make it into the sublime text.cfg and run backup and restore again. 
At last, it solved.

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced

### Improving the Mackup codebase

* [ ] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [ ] I have linted the code locally prior to submission
* [ ] I have written new tests as applicable
* [ ] I have added an explanation of what the changes do
