### PR TITLE
Add support for ni

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added support for PrusaSlicer (via @visika)
 - Added support for Logseq (via @visika)
 - Added support for SwitchHosts (via @zxjlm)
+- Add support for ni (via @wxh16144)
 
 ## Mackup 0.8.36
 

--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Netlify](https://www.netlify.com/)
 - [newsbeuter](http://newsbeuter.org/)
 - [ngrok](https://ngrok.com/)
+- [ni](https://github.com/antfu/ni/)
 - [Nomacs](http://nomacs.org/)
 - [NoSQLBooster for MongoDB](https://www.nosqlbooster.com/)
 - [notion-enhancer](https://notion-enhancer.github.io/)

--- a/mackup/applications/ni.cfg
+++ b/mackup/applications/ni.cfg
@@ -1,0 +1,5 @@
+[application]
+name = ni
+
+[configuration_files]
+.nirc


### PR DESCRIPTION

Synchronizing Package Manager Configuration Files.

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced

### Improving the Mackup codebase

* [ ] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [ ] I have linted the code locally prior to submission
* [ ] I have written new tests as applicable
* [ ] I have added an explanation of what the changes do
