### PR TITLE
Update iTerm2 support (fixes #1925)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Updated support for iTerm2 (via @jamesrtnz)
+
 ## Mackup 0.8.37
 
 - Added support for macOS Preview (via @iloveitaly)

--- a/mackup/applications/iterm2.cfg
+++ b/mackup/applications/iterm2.cfg
@@ -3,6 +3,4 @@ name = iTerm2
 
 [configuration_files]
 Library/Preferences/com.googlecode.iterm2.plist
-
-[xdg_configuration_files]
-iterm2/AppSupport/DynamicProfiles
+Library/Application Support/iTerm2/DynamicProfiles


### PR DESCRIPTION
This PR is a fix for #1925; it updates the configuration for iTerm2 to backup the actual "DynamicProfiles" subdirectory, rather than attempting to backup a symlinked copy.

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced