### PR TITLE
Add support for DBeaver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+- Added support for DBeaver (via @or-tal-0)
+
 ## Mackup 0.8.40
 
 - Add support for Trizen (via @cilenco)

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [DataGrip](https://www.jetbrains.com/datagrip/)
 - [Dash](https://kapeli.com/dash)
 - [Day-O](http://www.shauninman.com/archive/2011/10/20/day_o_mac_menu_bar_clock)
+- [DBeaver](https://dbeaver.io/)
 - [DbVisualizer](https://www.dbvis.com/)
 - [Deal Alert](http://dealalertapp.com/)
 - [Deepin-dde-dock](https://github.com/linuxdeepin/dde-dock)

--- a/mackup/applications/dbeaver.cfg
+++ b/mackup/applications/dbeaver.cfg
@@ -1,0 +1,6 @@
+[application]
+name = DBeaver
+
+[configuration_files]
+Library/DBeaverData/workspace6/.metadata/.plugins/org.eclipse.core.runtime/.settings
+Library/DBeaverData/workspace6/General


### PR DESCRIPTION
Note that `Workspace6` seems like installation specific, but is the default in all DBeaver installations.

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced

### Improving the Mackup codebase

* [x] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [x] I have linted the code locally prior to submission
* [ ] I have written new tests as applicable
* [x] I have added an explanation of what the changes do
