### PR TITLE
fix(doc/README.md): Remove Copy engine references

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -14,7 +14,7 @@ vi ~/.mackup.cfg
 You can specify the storage type Mackup will use to store your configuration
 files.
 
-For now, you have 4 options: `dropbox`, `google_drive`, `icloud`, `copy` and `file_system`.
+For now, you have 4 options: `dropbox`, `google_drive`, `icloud` and `file_system`.
 
 If none is specified, Mackup will try to use the default: `dropbox`.
 With the `dropbox` storage engine, Mackup will automatically figure out your
@@ -45,16 +45,6 @@ configuration files in the `~/Library/Mobile\ Documents/com\~apple\~CloudDocs/` 
 ```ini
 [storage]
 engine = icloud
-```
-
-### Copy
-
-If you choose the `copy` storage engine, Mackup will figure out
-where your Copy folder is and store your configuration files in it.
-
-```ini
-[storage]
-engine = copy
 ```
 
 ### File System


### PR DESCRIPTION
Remove Copy storage engine from `doc/README.md`

Related to #1957 and #1691

### All submissions

* [X] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change
