### PR TITLE
Add warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Mackup
 
+> [!WARNING]
+> With recent versions of macOS, the symlinking of config files no longer works, and apps may not save updates to the settings when using mackup. It is currently recommended to uninstall mackup until we have a feature that allows us to copy files instead of symlinking them. For more information on this, please visit https://github.com/lra/mackup/issues/1924.
+
 Keep your application settings in sync.
 
 ## Table of content


### PR DESCRIPTION
Hey,

since mackup seems to break on all new versions of macOS due to changes in symlinking, I think there should be a warning on the readme until the copy feature is shipped.

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

