### PR TITLE
remove redundant Library/Scripts from macosx

### DIFF
--- a/mackup/applications/macosx.cfg
+++ b/mackup/applications/macosx.cfg
@@ -6,6 +6,5 @@ name = MacOSX
 Library/KeyBindings/DefaultKeyBinding.dict
 Library/PDF Services
 Library/Preferences/com.apple.symbolichotkeys.plist
-Library/Scripts
 Library/Speech/Speakable Items
 Library/Workflows


### PR DESCRIPTION
Already exists in scripts.cfg

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [ ] This PR is only for one application
* [ ] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [ ] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced

### Improving the Mackup codebase

* [ ] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [x] I have linted the code locally prior to submission
* [x] I have written new tests as applicable
* [x] I have added an explanation of what the changes do
