### PR TITLE
Backup/restore specific applications

### DIFF
--- a/mackup/main.py
+++ b/mackup/main.py
@@ -8,7 +8,7 @@ Usage:
   mackup [options] backup [--] [<application> ...]
   mackup [options] restore [--] [<application> ...]
   mackup show <application>
-  mackup [options] uninstall
+  mackup [options] uninstall [--] [<application> ...]
   mackup (-h | --help)
   mackup --version
 
@@ -150,7 +150,13 @@ def main():
             app_names = mckp.get_apps_to_backup()
             app_names.discard(MACKUP_APP_NAME)
 
-            for app_name in sorted(app_names):
+            app_names = sorted(app_names)
+
+            # To allow for specific applications to be uninstalled, we replace the full list with only the valid ones from the command line
+            if args["<application>"]:
+                app_names = list(set(args["<application>"]) & set(app_names))
+
+            for app_name in app_names:
                 app = ApplicationProfile(
                     mckp, app_db.get_files(app_name), dry_run, verbose
                 )

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -5,8 +5,8 @@ Copyright (C) 2013-2021 Laurent Raufaste <http://glop.org/>
 
 Usage:
   mackup list
-  mackup [options] backup
-  mackup [options] restore
+  mackup [options] backup [--] [<application> ...]
+  mackup [options] restore [--] [<application> ...]
   mackup show <application>
   mackup [options] uninstall
   mackup (-h | --help)
@@ -179,8 +179,8 @@ def main():
 
     elif args["show"]:
         mckp.check_for_usable_environment()
-        app_name = args["<application>"]
-
+        app_name = args["<application>"][0] # Needed because args["<application>"] is now a list
+        
         # Make sure the app exists
         if app_name not in app_db.get_app_names():
             sys.exit("Unsupported application: {}".format(app_name))

--- a/mackup/main.py
+++ b/mackup/main.py
@@ -87,8 +87,14 @@ def main():
         # Check the env where the command is being run
         mckp.check_for_usable_backup_env()
 
+        applications = sorted(mckp.get_apps_to_backup())
+        
+        # To allow for specific applications to be backed up, we replace the full list with only the valid ones from the command line
+        if args["<application>"]:
+            applications = list(set(args["<application>"]) & set(applications))
+        
         # Backup each application
-        for app_name in sorted(mckp.get_apps_to_backup()):
+        for app_name in applications:
             app = ApplicationProfile(mckp, app_db.get_files(app_name), dry_run, verbose)
             printAppHeader(app_name)
             app.backup()
@@ -115,7 +121,13 @@ def main():
         # Mackup has already been done
         app_names.discard(MACKUP_APP_NAME)
 
-        for app_name in sorted(app_names):
+        app_names = sorted(app_names)
+
+        # To allow for specific applications to be restored up, we replace the full list with only the valid ones from the command line
+        if args["<application>"]:
+            app_names = list(set(args["<application>"]) & set(app_names))
+
+        for app_name in app_names:
             app = ApplicationProfile(mckp, app_db.get_files(app_name), dry_run, verbose)
             printAppHeader(app_name)
             app.restore()


### PR DESCRIPTION
This is a quick take at allowing backup/restore of specific applications. I found it useful for myself and found at least two people requesting it on #2019 and #1892. I'll try to add the option to do the same with the uninstall command in the future.

### All submissions

* [X ] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [ X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [ ] This PR is only for one application
* [ ] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [ ] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [ ] Syncing does not break the application
* [ ] Syncing does not compete with any syncing functionality internal to the application
* [ ] The configuration syncs the minimal set of data
* [ ] No file specific to the local workstation is synced
* [ ] No sensitive data is synced

### Improving the Mackup codebase

* [X] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [X] I have linted the code locally prior to submission
* [ ] I have written new tests as applicable
* [X] I have added an explanation of what the changes do
