### PR TITLE
[GnuPG] add pubring.kbx to config files list

### DIFF
--- a/doc/.mackup/gnupg.cfg
+++ b/doc/.mackup/gnupg.cfg
@@ -7,3 +7,4 @@ name = GnuPG
 .gnupg/secring.gpg
 .gnupg/trustdb.gpg
 .gnupg/pubring.gpg
+.gnupg/pubring.kbx


### PR DESCRIPTION
kbx is the public keyring using the new keybox format according to https://www.gnupg.org/documentation/manuals/gnupg/GPG-Configuration.html

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced

### Improving the Mackup codebase

* [x] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [x] I have linted the code locally prior to submission
* [x] I have written new tests as applicable
* [x] I have added an explanation of what the changes do
