### PR TITLE
Add support for XDG base directory for doomemacs and emacs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add support for Cursor (via @takyshu98)
 - Add support for PHPStorm 2024.1 (via @edwinvdpol)
 - Add support for WezTerm (via @asm0dey)
+- Add support for XDG Base Directory for doomemacs and emacs (via @psujit775)
 
 ## Mackup 0.8.40
 

--- a/mackup/applications/doom-emacs.cfg
+++ b/mackup/applications/doom-emacs.cfg
@@ -3,3 +3,4 @@ name = Doom Emacs
 
 [configuration_files]
 .doom.d
+.config/doom

--- a/mackup/applications/emacs.cfg
+++ b/mackup/applications/emacs.cfg
@@ -4,3 +4,4 @@ name = Emacs
 [configuration_files]
 .emacs
 .emacs.d
+.config/emacs


### PR DESCRIPTION
### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
* [x] Syncing does not break the application
* [x] Syncing does not compete with any syncing functionality internal to the application
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced

### Improving the Mackup codebase

* [x] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [x] I have linted the code locally prior to submission
* [x] I have written new tests as applicable
* [x] I have added an explanation of what the changes do
