### PR TITLE
Update rust.cfg to include .cargo/config.toml

### DIFF
--- a/mackup/applications/rust.cfg
+++ b/mackup/applications/rust.cfg
@@ -2,4 +2,5 @@
 name = Rust
 
 [configuration_files]
+.cargo/config.toml
 .cargo/config


### PR DESCRIPTION
Update `rust.cfg` to include `.cargo/config.toml` file.

> Since Cargo 1.39, Cargo officially supports and recommends to use `.cargo/config.toml`.
>
> Changelog reference: [Cargo 1.39 (2019-11-07)](https://doc.rust-lang.org/nightly/cargo/CHANGELOG.html#cargo-139-2019-11-07)

### All submissions

 - [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
 - [x]  I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

 - [x] This PR is only for one application
 - [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
 - [ ] Changes have been added to the WIP section of the [CHANGELOG](https://github.com/lra/mackup/blob/master/CHANGELOG.md)
 - [x] Syncing does not break the application
 - [x] Syncing does not compete with any syncing functionality internal to the application
 - [x] The configuration syncs the minimal set of data
 - [x] No file specific to the local workstation is synced
 - [x] No sensitive data is synced

### Improving the Mackup codebase
 - [x] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
 - [x] I have linted the code locally prior to submission
 - [ ] I have written new tests as applicable
 - [x] I have added an explanation of what the changes do
 