### PR TITLE
Add tests on arm

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - "ubuntu-22.04"
-          - "ubuntu-22.04-arm"
-          - "ubuntu-24.04"
-          - "ubuntu-24.04-arm"
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
         python-version:
           - "3.9"
           - "3.10"


### PR DESCRIPTION
This pull request updates the OS matrix in the GitHub Actions workflow configuration to expand support for ARM architectures alongside existing Ubuntu versions.

Platform support expansion:

* [`.github/workflows/install.yaml`](diffhunk://#diff-d45e2362afc2984f7b893466c3f6c2abdbd3d977e521913e1cdd549d15c3b827L14-R17): Added `ubuntu-22.04-arm` and `ubuntu-24.04-arm` to the matrix, enabling CI runs on ARM-based runners in addition to the current x86_64 Ubuntu versions.