### PR TITLE
Overwrite destination subfolders

### DIFF
--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -107,7 +107,7 @@ def copy(src: str, dst: str) -> None:
 
     # We need to copy a whole folder
     elif os.path.isdir(src):
-        shutil.copytree(src, dst)
+        shutil.copytree(src, dst, dirs_exist_ok=True)
 
     # What the heck is this?
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -209,6 +209,50 @@ class TestMackup(unittest.TestCase):
         utils.delete(srcpath)
         utils.delete(dstpath)
 
+    def test_copy_dir_that_exists(self):
+        """Copies a directory recursively to a destination path that already exists, overwriting it."""
+        # Create a source and a destination tmp folders
+        src_folder = tempfile.mkdtemp()
+        dst_folder = tempfile.mkdtemp()
+
+        # Create a folder inside the source folder
+        src_subfolder = tempfile.mkdtemp(dir=src_folder)
+
+        # Create the same subfolder inside the destination folder
+        src_subfolder_name = os.path.basename(src_subfolder)
+        dst_subfolder = os.path.join(dst_folder, src_subfolder_name)
+        os.mkdir(dst_subfolder)
+
+        # Create a tmp file in the src subfolder
+        src_file = tempfile.NamedTemporaryFile(delete=False, dir=src_subfolder)
+        src_file_name = src_file.name
+        src_file.close()
+
+        # Set the destination filename
+        dst_file = os.path.join(dst_subfolder, os.path.basename(src_file_name))
+
+        # Make sure the source file and destination folder exist and the
+        # destination file doesn't yet exist
+        assert os.path.isdir(src_folder)
+        assert os.path.isdir(src_subfolder)
+        assert os.path.isfile(src_file_name)
+        assert os.path.isdir(dst_folder)
+        assert os.path.isdir(dst_subfolder)
+        assert not os.path.exists(dst_file)
+
+        # Check if mackup can copy it
+        utils.copy(src_folder, dst_folder)
+        assert os.path.isdir(src_folder)
+        assert os.path.isdir(src_subfolder)
+        assert os.path.isfile(src_file_name)
+        assert os.path.isdir(dst_folder)
+        assert os.path.isdir(dst_subfolder)
+        assert os.path.exists(dst_file)
+
+        # Let's clean up
+        utils.delete(src_folder)
+        utils.delete(dst_folder)
+
     def test_link_file(self):
         # Create a tmp file
         tfile = tempfile.NamedTemporaryFile(delete=False)


### PR DESCRIPTION
This pull request improves the behavior of the `copy` utility function when copying directories to destinations that already exist, and adds a new test to ensure this functionality works as expected.

Improvements to directory copying:

* Updated the `copy` function in `mackup/utils.py` to use `shutil.copytree` with `dirs_exist_ok=True`, allowing it to overwrite existing directories at the destination instead of raising an error.

Testing enhancements:

* Added a new test `test_copy_dir_that_exists` in `tests/test_utils.py` to verify that copying a directory to an existing destination works correctly and overwrites as intended.

Fixes https://github.com/lra/mackup/issues/2089