### PR TITLE
Merge iStat Menus 6 into iStat Menus

### DIFF
--- a/mackup/applications/istat-menus-6.cfg
+++ b/mackup/applications/istat-menus-6.cfg
@@ -1,7 +1,0 @@
-[application]
-name = iStat Menus
-
-[configuration_files]
-Library/Preferences/com.bjango.istatmenus.plist
-Library/Preferences/com.bjango.istatmenus6.extras.plist
-Library/Preferences/com.bjango.istatmenus.status.plist

--- a/mackup/applications/istat-menus.cfg
+++ b/mackup/applications/istat-menus.cfg
@@ -2,8 +2,8 @@
 name = iStat Menus
 
 [configuration_files]
+Library/Preferences/com.bjango.istatmenus.menubar.7.plist
 Library/Preferences/com.bjango.istatmenus.plist
 Library/Preferences/com.bjango.istatmenus.status.plist
 Library/Preferences/com.bjango.istatmenus5.extras.plist
 Library/Preferences/com.bjango.istatmenus6.extras.plist
-Library/Preferences/com.bjango.istatmenus.menubar.7.plist


### PR DESCRIPTION
This pull request updates the configuration for iStat Menus in the Mackup backup system by removing an outdated configuration file and updating the list of configuration files for the latest version of iStat Menus.

iStat Menus configuration updates:

* Removed the obsolete `istat-menus-6.cfg` file, which referenced older configuration files for iStat Menus 6.
* Updated the `istat-menus.cfg` file by adding the `com.bjango.istatmenus.menubar.7.plist` configuration file to support iStat Menus 7, and reorganized the list to remove redundancy.