### PR TITLE
Add (use --force to skip this prompt) to the confirmation

### DIFF
--- a/mackup/application.py
+++ b/mackup/application.py
@@ -91,7 +91,7 @@ class ApplicationProfile(object):
                     if utils.confirm(
                         "A {} named {} already exists in the"
                         " Mackup folder.\nAre you sure that you want to"
-                        " replace it?".format(file_type, mackup_filepath)
+                        " replace it? (use --force to skip this prompt)".format(file_type, mackup_filepath)
                     ):
                         # If confirmed, delete the file in Mackup
                         utils.delete(mackup_filepath)


### PR DESCRIPTION
Add a note to the replacement prompt about using --force

```
Are you sure that you want to replace it? (use --force to skip this prompt) <Yes|No>
```

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change
### Improving the Mackup codebase

* [x] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [x] I have linted the code locally prior to submission
* [ ] ~I have written new tests as applicable~
* [x] I have added an explanation of what the changes do
