### PR TITLE
Use shutil.copy in copytree 

### DIFF
--- a/mackup/utils.py
+++ b/mackup/utils.py
@@ -103,7 +103,7 @@ def copy(src: str, dst: str) -> None:
     # We need to copy a single file
     if os.path.isfile(src):
         # Copy the src file to dst
-        shutil.copy2(src, dst)
+        shutil.copy(src, dst)
 
     # We need to copy a whole folder
     elif os.path.isdir(src):


### PR DESCRIPTION
We were already using `copy` for single files, so it's safe to use it for folders too.

Fixes #2115 