### PR TITLE
Handle permission errors when restore replaces existing files

### DIFF
--- a/src/mackup/application.py
+++ b/src/mackup/application.py
@@ -168,8 +168,15 @@ class ApplicationProfile:
                         " home folder.\nAre you sure that you want to"
                         " replace it?",
                     ):
-                        # If confirmed, delete the existing home file
-                        utils.delete(home_filepath)
+                        # If confirmed, delete the existing home file before restoring.
+                        try:
+                            utils.delete(home_filepath)
+                        except PermissionError as e:
+                            print(
+                                f"Error: Unable to copy file from {mackup_filepath} to "
+                                f"{home_filepath} due to permission issue: {e}",
+                            )
+                            continue
                     else:
                         continue
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -394,6 +394,37 @@ class TestApplicationProfile(unittest.TestCase):
         with open(home_filepath) as f:
             assert f.read() == "existing home"
 
+    def test_copy_files_from_mackup_folder_delete_permission_error(self):
+        """Test restore handles PermissionError when removing existing home file."""
+        test_file = ".testfile"
+        home_filepath = os.path.join(self.temp_home, test_file)
+        mackup_filepath = os.path.join(self.mock_mackup.mackup_folder, test_file)
+
+        with open(home_filepath, "w") as f:
+            f.write("existing home")
+        with open(mackup_filepath, "w") as f:
+            f.write("backup content")
+
+        with patch("mackup.application.utils.confirm", return_value=True), \
+             patch("mackup.application.utils.delete") as mock_delete, \
+             patch("mackup.application.utils.copy") as mock_copy:
+            mock_delete.side_effect = PermissionError("Permission denied")
+
+            captured_output = StringIO()
+            sys.stdout = captured_output
+
+            self.app_profile.copy_files_from_mackup_folder()
+
+            sys.stdout = sys.__stdout__
+
+            mock_delete.assert_called_once_with(home_filepath)
+            mock_copy.assert_not_called()
+
+            output = captured_output.getvalue()
+            assert "Error: Unable to copy file" in output
+            assert "permission issue" in output
+            assert home_filepath in output
+
     def test_link_uninstall_mackup_not_a_link(self):
         """Test link_uninstall skips when home file is not a symbolic link."""
         # Create a test file in the mackup directory (regular file, not a link)


### PR DESCRIPTION
## Summary
Fixes a restore crash when an existing destination path cannot be deleted due to filesystem permissions.

## Problem
During `mackup restore`, when a destination already exists and replacement is confirmed, Mackup deletes the existing path before copying from backup.
If deletion raises `PermissionError` (e.g. protected app-managed paths), restore currently crashes with a traceback.

## Changes
- In restore flow (`ApplicationProfile.copy_files_from_mackup_folder`), catch `PermissionError` around destination deletion.
- Print the same user-facing permission error message format used for copy failures.
- Skip that item and continue processing remaining files.
- Add regression test covering delete-time `PermissionError` during restore replacement.

## Validation
- Full test suite passes locally.
- New regression test included in `tests/test_application.py`.
