### PR TITLE
Makefile: Run ruff from uv environment and warn on missing markdownlint 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,7 @@ uv run pytest -v
 uv run mypy mackup/
 
 # Run linting
-ruff check .
+uv run ruff check .
 ```
 
 ### Code Quality Standards

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ lint:
 	markdownlint -c .markdownlint.yaml '**/*.md'
 
 ruff:
-	ruff check .
+	uv run ruff check .
 
 ty:
 	uv run ty check

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
+MDL_PATH := $(shell command -v markdownlint 2> /dev/null)
+
 lint:
+ifdef MDL_PATH
 	markdownlint -c .markdownlint.yaml '**/*.md'
+else
+	$(warning "[WARN] No 'markdownlint' utility in PATH. Consider installing it from your package manager.")
+	$(warning "[WARN] Markdown linting has been skipped.")
+endif
 
 ruff:
 	uv run ruff check .


### PR DESCRIPTION
These are a couple small issues I've found while trying to create a setup for development on this repo. The `markdownlint` skip seems appropriate to me as the dependency can't be directly installed in Python, and doesn't seem essential for most development (i.e. adding new applications). Please tell me if you think otherwise!

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [ ] This PR is only for one application
* [ ] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [ ] The configuration syncs the minimal set of data
* [ ] No file specific to the local workstation is synced
* [ ] No sensitive data is synced

### Improving the Mackup codebase

* [x] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [x] I have linted the code locally prior to submission
* [x] I have written new tests as applicable
* [x] I have added an explanation of what the changes do
