### PR TITLE
Add helix editor application support

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [HandBrake](https://handbrake.fr/)
 - [Hands Off!](http://www.oneperiodic.com/products/handsoff/)
 - [Hazel](http://www.noodlesoft.com/hazel.php)
+- [Helix](https://helix-editor.com/)
 - [Hero Lab](http://www.wolflair.com/index.php?context=hero_lab)
 - [Heroku](https://www.heroku.com/)
 - [HexChat](https://hexchat.github.io/)

--- a/src/mackup/applications/helix.cfg
+++ b/src/mackup/applications/helix.cfg
@@ -1,0 +1,7 @@
+[application]
+name = helix
+
+[xdg_configuration_files]
+helix/config.toml
+helix/languages.toml
+helix/themes


### PR DESCRIPTION
Relevant documentation:
https://docs.helix-editor.com/configuration.html

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced

### Improving the Mackup codebase

* [ ] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [ ] I have linted the code locally prior to submission
* [ ] I have written new tests as applicable
* [ ] I have added an explanation of what the changes do
