### PR TITLE
Add Context7 application support

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ See the [README](doc/README.md) file in the doc directory for more info.
 - [Concentrate](http://www.getconcentrating.com/)
 - [Conky](https://github.com/brndnmtthws/conky)
 - [Consular](https://github.com/achiu/consular)
+- [Context7](https://context7.com/)
 - [Contexts](https://contexts.co)
 - [ControlPlane](http://www.controlplaneapp.com/)
 - [CopyQ](https://github.com/hluk/CopyQ)

--- a/src/mackup/applications/context7.cfg
+++ b/src/mackup/applications/context7.cfg
@@ -1,0 +1,5 @@
+[application]
+name = Context7
+
+[configuration_files]
+.context7/credentials.json


### PR DESCRIPTION
## Summary
- Add Context7 to the supported applications list.
- Sync Context7 CLI credentials from `~/.context7/credentials.json`.
- Exclude `cli-state.json` because it only stores local version-check state.

## Checks
- `make check` passed locally.
- Markdown lint was skipped because `markdownlint` is not installed locally.