### PR TITLE
Remove trustdb.gpg from gnupg

### DIFF
--- a/src/mackup/applications/gnupg.cfg
+++ b/src/mackup/applications/gnupg.cfg
@@ -4,4 +4,3 @@ name = GnuPG
 [configuration_files]
 .gnupg/gpg-agent.conf
 .gnupg/gpg.conf
-.gnupg/trustdb.gpg


### PR DESCRIPTION
## Summary

From <https://www.gnupg.org/documentation/manuals/gnupg/GPG-Configuration.html>

`There is no need to backup this file; it is better to backup the ownertrust values`

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [x] This PR is only for one application
* [x] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [x] The configuration syncs the minimal set of data
* [x] No file specific to the local workstation is synced
* [x] No sensitive data is synced

### Improving the Mackup codebase

* [x] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [x] I have linted the code locally prior to submission
* [ ] I have written new tests as applicable
* [x] I have added an explanation of what the changes do