### PR TITLE
Add alternative backup folder for Ghostty

### DIFF
--- a/src/mackup/applications/ghostty.cfg
+++ b/src/mackup/applications/ghostty.cfg
@@ -3,3 +3,6 @@ name = Ghostty
 
 [xdg_configuration_files]
 ghostty/config
+
+[configuration_files]
+Library/Application Support/com.mitchellh.ghostty


### PR DESCRIPTION
This PR adds a secondary configuration folder for Ghostty. This is the folder where the configuration files are originally stored.

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Adding/updating Application X Support

* [ ] This PR is only for one application
* [ ] It has been added to the list of supported applications in the [README](https://github.com/lra/mackup/blob/master/README.md)
* [ ] The configuration syncs the minimal set of data
* [ ] No file specific to the local workstation is synced
* [ ] No sensitive data is synced

### Improving the Mackup codebase

* [ ] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [ ] I have linted the code locally prior to submission
* [ ] I have written new tests as applicable
* [ ] I have added an explanation of what the changes do
