### PR TITLE
Add yt-dlp config to youtube-dl app

### DIFF
--- a/src/mackup/applications/youtube-dl.cfg
+++ b/src/mackup/applications/youtube-dl.cfg
@@ -3,3 +3,4 @@ name = youtube-dl
 
 [xdg_configuration_files]
 youtube-dl/config
+yt-dlp/config


### PR DESCRIPTION
## Summary

- Back up yt-dlp's recommended XDG config path in the existing youtube-dl application profile.
- Keep this as part of the youtube-dl app because yt-dlp is the maintained fork/drop-in successor.

## Testing

- uv run pytest