### PR TITLE
Back up, restore, and link a specific application

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,31 +73,44 @@ You can find more detailed instructions in [INSTALL.md](INSTALL.md).
 
 ## Usage
 
-`mackup backup`
+`backup`, `restore`, `link install`, `link uninstall` and `link` operate on all
+of your configured applications by default. To limit a command to a single
+application, add its name (the identifier shown by `mackup list`), e.g.
+`mackup backup vim`. Naming an application overrides the
+`[applications_to_sync]` / `[applications_to_ignore]` settings in your
+`.mackup.cfg`, so you can act on any supported app without editing your config.
+
+`mackup backup [application]`
 
 Back up your application files. Copy your local config files into the Mackup folder.
+Name an application to back up only that one, e.g. `mackup backup vim`.
 
-`mackup restore`
+`mackup restore [application]`
 
 Restore your application settings on a newly installed workstation.
 Copy config files from the Mackup folder to your home folder.
+Name an application to restore only that one, e.g. `mackup restore emacs`.
 
-`mackup link install`
+`mackup link install [application]`
 
 Move your local config files into the Mackup folder,
 and link them to their original place.
+Name an application to install only that one.
 
 $${\color{red}warning}$$ _the `link` strategy [doesn't work correctly on macOS](#link-mode)_
 
-`mackup link`
+`mackup link [application]`
 
 On another workstation, links local config files from the Mackup folder.
+Name an application to link only that one.
 
-`mackup link uninstall`
+`mackup link uninstall [application]`
 
 Copy back any synced config file to its original place.
 Removes the links and copies config files from the Mackup folder back into your
 home.
+Name an application (e.g. `mackup link uninstall git`) to unlink only that one;
+scoping to an application skips the global uninstall confirmation.
 
 `mackup list`
 
@@ -188,6 +201,11 @@ mackup link uninstall
 This will remove the symlinks and copy back the files from the Mackup folder in
 Dropbox to their original places in your home. The Mackup folder and the files
 in it stay put, so that any other computer also running Mackup is unaffected.
+
+To revert a single application instead, name it, e.g. `mackup link uninstall
+git`. Scoping the command to an application unlinks only that app — the rest of
+your setup and the Mackup config itself are left in place, and the global
+uninstall confirmation is skipped.
 
 ## Supported Storages
 

--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ This will remove the symlinks and copy back the files from the Mackup folder in
 Dropbox to their original places in your home. The Mackup folder and the files
 in it stay put, so that any other computer also running Mackup is unaffected.
 
-To revert a single application instead, name it, e.g. `mackup link uninstall
-git`. Scoping the command to an application unlinks only that app — the rest of
-your setup and the Mackup config itself are left in place, and the global
-uninstall confirmation is skipped.
+To revert a single application instead, name it, e.g.
+`mackup link uninstall git`. Scoping the command to an application unlinks only
+that app — the rest of your setup and the Mackup config itself are left in
+place, and the global uninstall confirmation is skipped.
 
 ## Supported Storages
 

--- a/src/mackup/mackup.py
+++ b/src/mackup/mackup.py
@@ -8,8 +8,6 @@ The only UI for now is the command line.
 
 import os
 import os.path
-import shutil
-import tempfile
 from typing import Optional
 
 from . import appsdb, config, utils
@@ -23,7 +21,6 @@ class Mackup:
         self._config: config.Config = config.Config(config_file)
 
         self.mackup_folder: str = self._config.fullpath
-        self.temp_folder: str = tempfile.mkdtemp(prefix="mackup_tmp_")
 
     def check_for_usable_environment(self) -> None:
         """Check if the current env is usable and has everything's required."""
@@ -64,10 +61,6 @@ class Mackup:
                 "You might want to back up some files or get your"
                 " storage directory synced first.",
             )
-
-    def clean_temp_folder(self) -> None:
-        """Delete the temp folder and files created while running."""
-        shutil.rmtree(self.temp_folder)
 
     def create_mackup_home(self) -> None:
         """If the Mackup home folder does not exist, create it."""

--- a/src/mackup/main.py
+++ b/src/mackup/main.py
@@ -302,6 +302,3 @@ def main() -> None:
                 )
                 print_app_header(app_name)
                 app.link()
-
-    # Delete the tmp folder
-    mckp.clean_temp_folder()

--- a/src/mackup/main.py
+++ b/src/mackup/main.py
@@ -6,11 +6,11 @@ Copyright (C) 2013-2025 Laurent Raufaste <http://glop.org/>
 Usage:
   mackup [options] list
   mackup [options] show <application>
-  mackup [options] backup
-  mackup [options] restore
-  mackup [options] link install
-  mackup [options] link
-  mackup [options] link uninstall
+  mackup [options] backup [<application>]
+  mackup [options] restore [<application>]
+  mackup [options] link install [<application>]
+  mackup [options] link uninstall [<application>]
+  mackup [options] link [<application>]
   mackup (-h | --help)
 
 Options:
@@ -29,8 +29,13 @@ Modes of action:
  - mackup backup: copy local config files in the configured remote folder.
  - mackup restore: copy config files from the configured remote folder locally.
  - mackup link install: moves local config files in remote folder, and links.
- - mackup link: links local config files from the remote folder.
  - mackup link uninstall: removes the links and copy config files locally.
+ - mackup link: links local config files from the remote folder.
+
+backup, restore, link install, link uninstall and link act on every configured
+application by default. Name a single application (e.g. `mackup backup vim`) to
+limit a command to that app, overriding the applications_to_sync and
+applications_to_ignore settings in your config.
 
 By default, Mackup syncs all application data via
 Dropbox, but may be configured to exclude applications or use a different
@@ -92,6 +97,21 @@ def main() -> None:
             header_str = header("---")
             print(f"\n{header_str} {bold(app_name)} {header_str}")
 
+    def apps_to_process(app_name: Optional[str]) -> set[str]:
+        """Resolve which apps a per-app command should act on.
+
+        If an application is named, error out when it is not a supported app
+        (like the `show` command) and otherwise act on exactly that app,
+        overriding the config's applications_to_sync / applications_to_ignore
+        lists. If no application is named, fall back to every configured
+        application.
+        """
+        if app_name:
+            if app_name not in app_db.get_app_names():
+                sys.exit(f"Unsupported application: {app_name}")
+            return {app_name}
+        return mckp.get_apps_to_backup()
+
     # If we want to answer mackup with "yes" for each question
     if args["--force"]:
         utils.FORCE_YES = True
@@ -135,45 +155,56 @@ def main() -> None:
         for file in app_db.get_files(requested_app_name):
             print(f" - {file}")
 
-    # mackup backup
+    # mackup backup [<application>]
     elif args["backup"]:
         mckp.check_for_usable_backup_env()
 
         # Create a backup of the files of each application
-        for app_name in sorted(mckp.get_apps_to_backup()):
+        for app_name in sorted(apps_to_process(args["<application>"])):
             app: ApplicationProfile = ApplicationProfile(
                 mckp, app_db.get_files(app_name), dry_run, verbose,
             )
             print_app_header(app_name)
             app.copy_files_to_mackup_folder()
 
-    # mackup restore
+    # mackup restore [<application>]
     elif args["restore"]:
         mckp.check_for_usable_restore_env()
 
         # Recover a backup of the files of each application
-        for app_name in sorted(mckp.get_apps_to_backup()):
+        for app_name in sorted(apps_to_process(args["<application>"])):
             app = ApplicationProfile(mckp, app_db.get_files(app_name), dry_run, verbose)
             print_app_header(app_name)
             app.copy_files_from_mackup_folder()
 
-    # mackup link install
+    # mackup link install [<application>]
     elif args["link"] and args["install"]:
         # Check the env where the command is being run
         mckp.check_for_usable_backup_env()
 
         # Create a link for each application
-        for app_name in sorted(mckp.get_apps_to_backup()):
+        for app_name in sorted(apps_to_process(args["<application>"])):
             app = ApplicationProfile(mckp, app_db.get_files(app_name), dry_run, verbose)
             print_app_header(app_name)
             app.link_install()
 
-    # mackup link uninstall
+    # mackup link uninstall [<application>]
     elif args["link"] and args["uninstall"]:
         # Check the env where the command is being run
         mckp.check_for_usable_restore_env()
 
-        if dry_run or (
+        if args["<application>"]:
+            # Unlink only the named application, leaving the rest of Mackup
+            # (and the Mackup config itself) in place. No global confirmation
+            # is needed since the user explicitly scoped the uninstall.
+            for app_name in sorted(apps_to_process(args["<application>"])):
+                app = ApplicationProfile(
+                    mckp, app_db.get_files(app_name), dry_run, verbose,
+                )
+                print_app_header(app_name)
+                app.link_uninstall()
+
+        elif dry_run or (
             utils.confirm(
                 "You are going to uninstall Mackup.\n"
                 "Every configuration file, setting and dotfile"
@@ -214,33 +245,46 @@ def main() -> None:
                 "Thanks for using Mackup!",
             )
 
-    # mackup link
+    # mackup link [<application>]
     elif args["link"]:
         # Check the env where the command is being run
         mckp.check_for_usable_restore_env()
 
-        # Restore the Mackup config before any other config, as we might need
-        # it to know about custom settings
-        mackup_app = ApplicationProfile(
-            mckp, app_db.get_files(MACKUP_APP_NAME), dry_run, verbose,
-        )
-        print_app_header(MACKUP_APP_NAME)
-        mackup_app.link()
+        if args["<application>"]:
+            # Link only the named application. No need to restore the Mackup
+            # config first, as the app set is fixed and config-independent here.
+            for app_name in sorted(apps_to_process(args["<application>"])):
+                app = ApplicationProfile(
+                    mckp, app_db.get_files(app_name), dry_run, verbose,
+                )
+                print_app_header(app_name)
+                app.link()
+        else:
+            # Restore the Mackup config before any other config, as we might
+            # need it to know about custom settings
+            mackup_app = ApplicationProfile(
+                mckp, app_db.get_files(MACKUP_APP_NAME), dry_run, verbose,
+            )
+            print_app_header(MACKUP_APP_NAME)
+            mackup_app.link()
 
-        # Initialize again the apps db, as the Mackup config might have changed
-        # it
-        mckp = Mackup(config_file)
-        app_db = ApplicationsDatabase()
+            # Initialize again the apps db, as the Mackup config might have
+            # changed it
+            mckp = Mackup(config_file)
+            app_db = ApplicationsDatabase()
 
-        # Restore the rest of the app configs, using the restored Mackup config
-        app_names = mckp.get_apps_to_backup()
-        # Mackup has already been done
-        app_names.discard(MACKUP_APP_NAME)
+            # Restore the rest of the app configs, using the restored Mackup
+            # config
+            app_names = mckp.get_apps_to_backup()
+            # Mackup has already been done
+            app_names.discard(MACKUP_APP_NAME)
 
-        for app_name in sorted(app_names):
-            app = ApplicationProfile(mckp, app_db.get_files(app_name), dry_run, verbose)
-            print_app_header(app_name)
-            app.link()
+            for app_name in sorted(app_names):
+                app = ApplicationProfile(
+                    mckp, app_db.get_files(app_name), dry_run, verbose,
+                )
+                print_app_header(app_name)
+                app.link()
 
     # Delete the tmp folder
     mckp.clean_temp_folder()

--- a/src/mackup/main.py
+++ b/src/mackup/main.py
@@ -157,10 +157,14 @@ def main() -> None:
 
     # mackup backup [<application>]
     elif args["backup"]:
+        # Resolve and validate the target apps before the env check, so an
+        # unknown application name fails cleanly without creating the Mackup
+        # folder or prompting first.
+        app_names = apps_to_process(args["<application>"])
         mckp.check_for_usable_backup_env()
 
         # Create a backup of the files of each application
-        for app_name in sorted(apps_to_process(args["<application>"])):
+        for app_name in sorted(app_names):
             app: ApplicationProfile = ApplicationProfile(
                 mckp, app_db.get_files(app_name), dry_run, verbose,
             )
@@ -169,35 +173,43 @@ def main() -> None:
 
     # mackup restore [<application>]
     elif args["restore"]:
+        app_names = apps_to_process(args["<application>"])
         mckp.check_for_usable_restore_env()
 
         # Recover a backup of the files of each application
-        for app_name in sorted(apps_to_process(args["<application>"])):
+        for app_name in sorted(app_names):
             app = ApplicationProfile(mckp, app_db.get_files(app_name), dry_run, verbose)
             print_app_header(app_name)
             app.copy_files_from_mackup_folder()
 
     # mackup link install [<application>]
     elif args["link"] and args["install"]:
+        app_names = apps_to_process(args["<application>"])
         # Check the env where the command is being run
         mckp.check_for_usable_backup_env()
 
         # Create a link for each application
-        for app_name in sorted(apps_to_process(args["<application>"])):
+        for app_name in sorted(app_names):
             app = ApplicationProfile(mckp, app_db.get_files(app_name), dry_run, verbose)
             print_app_header(app_name)
             app.link_install()
 
     # mackup link uninstall [<application>]
     elif args["link"] and args["uninstall"]:
+        # Validate any named application before the env check, so an unknown
+        # name fails cleanly before any prompt or side effect.
+        named_apps = (
+            apps_to_process(args["<application>"]) if args["<application>"] else None
+        )
+
         # Check the env where the command is being run
         mckp.check_for_usable_restore_env()
 
-        if args["<application>"]:
+        if named_apps is not None:
             # Unlink only the named application, leaving the rest of Mackup
             # (and the Mackup config itself) in place. No global confirmation
             # is needed since the user explicitly scoped the uninstall.
-            for app_name in sorted(apps_to_process(args["<application>"])):
+            for app_name in sorted(named_apps):
                 app = ApplicationProfile(
                     mckp, app_db.get_files(app_name), dry_run, verbose,
                 )
@@ -247,13 +259,18 @@ def main() -> None:
 
     # mackup link [<application>]
     elif args["link"]:
+        # Validate any named application before the env check.
+        named_apps = (
+            apps_to_process(args["<application>"]) if args["<application>"] else None
+        )
+
         # Check the env where the command is being run
         mckp.check_for_usable_restore_env()
 
-        if args["<application>"]:
+        if named_apps is not None:
             # Link only the named application. No need to restore the Mackup
             # config first, as the app set is fixed and config-independent here.
-            for app_name in sorted(apps_to_process(args["<application>"])):
+            for app_name in sorted(named_apps):
                 app = ApplicationProfile(
                     mckp, app_db.get_files(app_name), dry_run, verbose,
                 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -342,6 +342,8 @@ class TestCLI(unittest.TestCase):
                 main()
             assert "Unsupported application" in str(context.value)
 
+        # The unknown name must fail before the env check creates the folder.
+        assert not os.path.exists(self.mackup_folder)
         backed_up_file = os.path.join(self.mackup_folder, self.test_file_name)
         assert not os.path.exists(backed_up_file)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -389,6 +389,51 @@ class TestCLI(unittest.TestCase):
         assert os.path.exists(self.test_file_path)
         assert not os.path.islink(self.test_file_path)
 
+    def test_restore_single_named_app(self):
+        """mackup restore <app> restores that application's files."""
+        # Back up first, then remove the home file.
+        with patch("sys.argv", ["mackup", "backup", "test-app"]):
+            main()
+        assert os.path.exists(os.path.join(self.mackup_folder, self.test_file_name))
+        os.remove(self.test_file_path)
+        assert not os.path.exists(self.test_file_path)
+
+        # Scoped restore.
+        with patch("sys.argv", ["mackup", "restore", "test-app"]):
+            main()
+
+        assert os.path.exists(self.test_file_path)
+        with open(self.test_file_path) as f:
+            assert f.read() == "test_config=value\n"
+
+    def test_link_install_single_named_app(self):
+        """mackup link install <app> links that application's files."""
+        with patch("sys.argv", ["mackup", "link", "install", "test-app"]):
+            main()
+
+        # The home file is now a symlink into the Mackup folder.
+        mackup_file = os.path.join(self.mackup_folder, self.test_file_name)
+        assert os.path.islink(self.test_file_path)
+        assert os.path.exists(mackup_file)
+        assert os.path.samefile(self.test_file_path, mackup_file)
+
+    def test_link_single_named_app(self):
+        """mackup link <app> links that application's files from the storage."""
+        # Put the file in the Mackup folder, then simulate a fresh home.
+        with patch("sys.argv", ["mackup", "backup", "test-app"]):
+            main()
+        os.remove(self.test_file_path)
+        assert not os.path.exists(self.test_file_path)
+
+        # Scoped link.
+        with patch("sys.argv", ["mackup", "link", "test-app"]):
+            main()
+
+        # The home file is now a symlink into the Mackup folder.
+        mackup_file = os.path.join(self.mackup_folder, self.test_file_name)
+        assert os.path.islink(self.test_file_path)
+        assert os.path.samefile(self.test_file_path, mackup_file)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import os
 import shutil
 import tempfile
@@ -322,6 +324,68 @@ class TestCLI(unittest.TestCase):
                 str(context.value)
                 == "Options --force and --force-no are mutually exclusive."
             )
+
+    def test_backup_single_named_app(self):
+        """mackup backup <app> backs up that application's files."""
+        with patch("sys.argv", ["mackup", "backup", "test-app"]):
+            main()
+
+        backed_up_file = os.path.join(self.mackup_folder, self.test_file_name)
+        assert os.path.exists(backed_up_file)
+        with open(backed_up_file) as f:
+            assert f.read() == "test_config=value\n"
+
+    def test_backup_unsupported_app_exits_with_error(self):
+        """mackup backup <unknown> exits with an error and backs nothing up."""
+        with patch("sys.argv", ["mackup", "backup", "definitely-not-an-app"]):
+            with pytest.raises(SystemExit) as context:
+                main()
+            assert "Unsupported application" in str(context.value)
+
+        backed_up_file = os.path.join(self.mackup_folder, self.test_file_name)
+        assert not os.path.exists(backed_up_file)
+
+    def test_backup_named_app_overrides_config(self):
+        """Naming an app overrides the config's sync/ignore selection."""
+        # A second, supported application that is NOT in [applications_to_sync].
+        second_file_name = ".testrc2"
+        second_file_path = os.path.join(self.test_home, second_file_name)
+        with open(second_file_path, "w") as f:
+            f.write("second=value\n")
+
+        second_app_config = os.path.join(self.custom_apps_dir, "test-app-2.cfg")
+        with open(second_app_config, "w") as f:
+            f.write("[application]\n")
+            f.write("name = test-app-2\n")
+            f.write("\n")
+            f.write("[configuration_files]\n")
+            f.write(f"{second_file_name}\n")
+
+        # Even though test-app-2 is not in [applications_to_sync], naming it
+        # explicitly backs it up.
+        with patch("sys.argv", ["mackup", "backup", "test-app-2"]):
+            main()
+
+        assert os.path.exists(os.path.join(self.mackup_folder, second_file_name))
+
+    def test_link_uninstall_single_app_skips_global_teardown(self):
+        """Scoped link uninstall unlinks one app without the global teardown."""
+        # Put the app under link management first.
+        with patch("sys.argv", ["mackup", "link", "install"]):
+            main()
+        assert os.path.islink(self.test_file_path)
+
+        # Uninstall just this app.
+        buffer = io.StringIO()
+        with patch("sys.argv", ["mackup", "link", "uninstall", "test-app"]):
+            with contextlib.redirect_stdout(buffer):
+                main()
+            # The global "all done" message must not appear for a scoped run.
+            assert "Thanks for using Mackup!" not in buffer.getvalue()
+
+        # The file is back in place as a regular file, not a symlink.
+        assert os.path.exists(self.test_file_path)
+        assert not os.path.islink(self.test_file_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`mackup backup`, `restore`, `link install`, `link uninstall` and `link` currently
operate on **all** configured applications. This PR lets you scope any of them to a
single application by name:

```
mackup backup vim
mackup restore emacs
mackup link uninstall git
```

This is one of the most-requested missing features and makes it easy to smoke-test
or re-sync a single config without editing `.mackup.cfg`. It supersedes the stale
#2034 and #968.

## Behavior

- Naming an application **overrides** your `[applications_to_sync]` /
  `[applications_to_ignore]` selection — it acts on exactly that app. An unknown
  name errors out like `show` does (`Unsupported application: <name>`).
- Scoped `link uninstall <app>` unlinks only that app: it skips the global
  "You are going to uninstall Mackup" confirmation, leaves the Mackup config in
  place, and omits the "Thanks for using Mackup!" message.
- Scoped `link <app>` links only that app, skipping the restore-Mackup-config-first
  / db-reinit step that only matters for a full restore.
- **Fully backward compatible** — bare `backup` / `restore` / `link …` and `show`
  are unchanged.

## Note on the docstring

The `link` usage lines are reordered so `link install` and `link uninstall` precede
bare `link`. With the new optional argument, docopt(-ng) otherwise matches bare
`link` first and swallows the `install`/`uninstall` keyword as an application name
(`mackup link uninstall git` → app `uninstall`). Verified against the pinned parser.

- Closes #611
- Closes #968 
- Closes #1128
- Closes #2034
- Closes #2172

### All submissions

* [x] I have followed the [Contributing Guidelines](https://github.com/lra/mackup/blob/master/.github/CONTRIBUTING.md)
* [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lra/mackup/pulls) for the same update/change

### Improving the Mackup codebase

* [x] My submission passes the [tests](https://github.com/lra/mackup/tree/master/tests)
* [x] I have linted the code locally prior to submission
* [x] I have written new tests as applicable
* [x] I have added an explanation of what the changes do
