### PR TITLE
Enforce SIM115

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,5 @@ ignore = [
     "C901", # mccabe complexity - too complex functions
     "PLR0912", # too many branches
     "PTH", # use pathlib - os.path is fine for this codebase
-    "SIM115", # use context manager for open - some cases require this
     "SLF001", # private member access - needed for testing
 ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,9 +35,8 @@ class TestMackup(unittest.TestCase):
 
     def test_delete_file(self):
         # Create a tmp file
-        tfile = tempfile.NamedTemporaryFile(delete=False)
-        tfpath = tfile.name
-        tfile.close()
+        with tempfile.NamedTemporaryFile(delete=False) as tfile:
+            tfpath = tfile.name
 
         # Make sure the created file exists
         assert os.path.isfile(tfpath)
@@ -51,17 +50,15 @@ class TestMackup(unittest.TestCase):
         tfpath = tempfile.mkdtemp()
 
         # Let's put a file in it just for fun
-        tfile = tempfile.NamedTemporaryFile(dir=tfpath, delete=False)
-        filepath = tfile.name
-        tfile.close()
+        with tempfile.NamedTemporaryFile(dir=tfpath, delete=False) as tfile:
+            filepath = tfile.name
 
         # Let's put another folder in it
         subfolder_path = tempfile.mkdtemp(dir=tfpath)
 
         # And a file in the subfolder
-        tfile = tempfile.NamedTemporaryFile(dir=subfolder_path, delete=False)
-        subfilepath = tfile.name
-        tfile.close()
+        with tempfile.NamedTemporaryFile(dir=subfolder_path, delete=False) as tfile:
+            subfilepath = tfile.name
 
         # Make sure the created files and folders exists
         assert os.path.isdir(tfpath)
@@ -78,9 +75,8 @@ class TestMackup(unittest.TestCase):
 
     def test_copy_file(self):
         # Create a tmp file
-        tfile = tempfile.NamedTemporaryFile(delete=False)
-        srcfile = tfile.name
-        tfile.close()
+        with tempfile.NamedTemporaryFile(delete=False) as tfile:
+            srcfile = tfile.name
 
         # Create a tmp folder
         dstpath = tempfile.mkdtemp()
@@ -104,9 +100,8 @@ class TestMackup(unittest.TestCase):
 
     def test_copy_fail(self):
         # Create a tmp FIFO file
-        tfile = tempfile.NamedTemporaryFile()
-        srcfile = tfile.name
-        tfile.close()
+        with tempfile.NamedTemporaryFile() as tfile:
+            srcfile = tfile.name
         os.mkfifo(srcfile)
 
         # Create a tmp folder
@@ -139,9 +134,8 @@ class TestMackup(unittest.TestCase):
         srcpath = tempfile.mkdtemp()
 
         # Create a tmp file
-        tfile = tempfile.NamedTemporaryFile(delete=False, dir=srcpath)
-        srcfile = tfile.name
-        tfile.close()
+        with tempfile.NamedTemporaryFile(delete=False, dir=srcpath) as tfile:
+            srcfile = tfile.name
 
         # Create a tmp folder
         dstpath = tempfile.mkdtemp()
@@ -175,9 +169,8 @@ class TestMackup(unittest.TestCase):
         srcpath = tempfile.mkdtemp()
 
         # Create a tmp file
-        tfile = tempfile.NamedTemporaryFile(delete=False, dir=srcpath)
-        srcfile = tfile.name
-        tfile.close()
+        with tempfile.NamedTemporaryFile(delete=False, dir=srcpath) as tfile:
+            srcfile = tfile.name
 
         # Create a tmp folder
         dstpath = tempfile.mkdtemp()
@@ -218,9 +211,8 @@ class TestMackup(unittest.TestCase):
         os.mkdir(dst_subfolder)
 
         # Create a tmp file in the src subfolder
-        src_file = tempfile.NamedTemporaryFile(delete=False, dir=src_subfolder)
-        src_file_name = src_file.name
-        src_file.close()
+        with tempfile.NamedTemporaryFile(delete=False, dir=src_subfolder) as src_file:
+            src_file_name = src_file.name
 
         # Set the destination filename
         dst_file = os.path.join(dst_subfolder, os.path.basename(src_file_name))
@@ -249,9 +241,8 @@ class TestMackup(unittest.TestCase):
 
     def test_link_file(self):
         # Create a tmp file
-        tfile = tempfile.NamedTemporaryFile(delete=False)
-        srcfile = tfile.name
-        tfile.close()
+        with tempfile.NamedTemporaryFile(delete=False) as tfile:
+            srcfile = tfile.name
 
         # Create a tmp folder
         dstpath = tempfile.mkdtemp()
@@ -276,8 +267,8 @@ class TestMackup(unittest.TestCase):
 
     def test_chmod_file(self):
         # Create a tmp file
-        tfile = tempfile.NamedTemporaryFile(delete=False)
-        file_name = tfile.name
+        with tempfile.NamedTemporaryFile(delete=False) as tfile:
+            file_name = tfile.name
 
         # Create a tmp directory with a sub folder
         dir_name = tempfile.mkdtemp()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,6 +96,7 @@ class TestMackup(unittest.TestCase):
         assert os.path.exists(dstfile)
 
         # Let's clean up
+        utils.delete(srcfile)
         utils.delete(dstpath)
 
     def test_copy_fail(self):
@@ -263,6 +264,7 @@ class TestMackup(unittest.TestCase):
         assert os.readlink(dstfile) == srcfile
 
         # Let's clean up
+        utils.delete(srcfile)
         utils.delete(dstpath)
 
     def test_chmod_file(self):
@@ -301,6 +303,10 @@ class TestMackup(unittest.TestCase):
         # Use an "unsupported file type". In this case, /dev/null
         with pytest.raises(ValueError, match="Unsupported file type"):
             utils.chmod(os.devnull)
+
+        # Let's clean up
+        utils.delete(file_name)
+        utils.delete(dir_name)
 
     def test_error(self):
         test_string = "Hello World"


### PR DESCRIPTION
This pull request refactors the test suite to use context managers (`with` statements) when creating temporary files with `tempfile.NamedTemporaryFile`, ensuring that files are properly closed and cleaned up. Additionally, it removes the lint ignore for the rule enforcing context manager usage for file operations.