### PR TITLE
Don't chmod temporarily orphaned symlinks during restore

### DIFF
--- a/src/mackup/utils.py
+++ b/src/mackup/utils.py
@@ -180,7 +180,11 @@ def chmod(target: str) -> None:
             for cur_dir in dirs:
                 os.chmod(os.path.join(root, cur_dir), folder_mode)
             for cur_file in files:
-                os.chmod(os.path.join(root, cur_file), file_mode)
+                fullpath = os.path.join(root, cur_file)
+                # Skip orphaned symlinks (e.g. links restored before their
+                # target), which os.walk lists but os.chmod can't follow
+                if os.path.isfile(fullpath):
+                    os.chmod(fullpath, file_mode)
 
     else:
         raise ValueError(f"Unsupported file type: {target}")

--- a/src/mackup/utils.py
+++ b/src/mackup/utils.py
@@ -181,11 +181,16 @@ def chmod(target: str) -> None:
                 os.chmod(os.path.join(root, cur_dir), folder_mode)
             for cur_file in files:
                 fullpath = os.path.join(root, cur_file)
-                # Skip broken symlinks (e.g. links restored before their
-                # target), which os.walk lists but os.chmod can't follow
-                if os.path.islink(fullpath) and not os.path.exists(fullpath):
-                    continue
-                os.chmod(fullpath, file_mode)
+                try:
+                    os.chmod(fullpath, file_mode)
+                except FileNotFoundError:
+                    # A broken symlink (e.g. a link restored before its
+                    # target) is listed by os.walk but can't be followed by
+                    # os.chmod. Skip it instead of crashing; re-raise for
+                    # real missing regular files.
+                    if os.path.islink(fullpath):
+                        continue
+                    raise
 
     else:
         raise ValueError(f"Unsupported file type: {target}")

--- a/src/mackup/utils.py
+++ b/src/mackup/utils.py
@@ -181,10 +181,11 @@ def chmod(target: str) -> None:
                 os.chmod(os.path.join(root, cur_dir), folder_mode)
             for cur_file in files:
                 fullpath = os.path.join(root, cur_file)
-                # Skip orphaned symlinks (e.g. links restored before their
+                # Skip broken symlinks (e.g. links restored before their
                 # target), which os.walk lists but os.chmod can't follow
-                if os.path.isfile(fullpath):
-                    os.chmod(fullpath, file_mode)
+                if os.path.islink(fullpath) and not os.path.exists(fullpath):
+                    continue
+                os.chmod(fullpath, file_mode)
 
     else:
         raise ValueError(f"Unsupported file type: {target}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -304,7 +304,21 @@ class TestMackup(unittest.TestCase):
         with pytest.raises(ValueError, match="Unsupported file type"):
             utils.chmod(os.devnull)
 
-        # Let's clean up
+        # # Orphaned symlink test
+
+        # An orphaned symlink (e.g. a link restored before its target) is
+        # listed by os.walk but can't be followed by os.chmod. utils.chmod
+        # must skip it instead of crashing with FileNotFoundError.
+        link_target = os.path.join(nested_dir, "orphaned_target")
+        link_name = os.path.join(dir_name, "orphaned_link")
+        os.symlink(link_target, link_name)
+        assert not os.path.exists(link_target)
+        assert os.path.islink(link_name)
+
+        # This used to raise FileNotFoundError
+        utils.chmod(dir_name)
+
+        # # Let's clean up
         utils.delete(file_name)
         utils.delete(dir_name)
 


### PR DESCRIPTION
## What

`utils.chmod()` crashes with `FileNotFoundError` when a directory contains an **orphaned symlink** (a link whose target doesn't exist).

`os.walk` lists symlinks among `files`, and `os.chmod` follows symlinks by default, so chmodding an orphaned link fails. This happens during `mackup restore` when a link is restored before the file it points to (e.g. the fish/fisherman ordering case from #710).

## Fix

Skip entries that aren't real files (`os.path.isfile` is `False` for orphaned symlinks, `True` for valid ones — preserving prior follow-the-link behavior).

## Test

Extended `test_chmod_file` with an orphaned-symlink case that reproduced the original crash. Full `tests/test_utils.py` suite passes (20 passed).

---

Supersedes #971 by @glaszig, reworked for the current `src/` layout and pytest.